### PR TITLE
Fix Incorrect Version Checking

### DIFF
--- a/src/IP.php
+++ b/src/IP.php
@@ -199,8 +199,8 @@ class IP
     public function getVersion()
     {
         if ($this->version === null) {
-            $ip = preg_replace('/^\0{12}/', '', $this->getBinary());
-            $this->version = $this->getIpLength($ip) < 16
+            $this->version = strpos($binary = $this->getBinary(), str_repeat($nibble = "\0\0", 5)) === 0
+                && in_array(substr($binary, 10, 2), [$nibble, ~$nibble], true)
                 ? self::VERSION_4
                 : self::VERSION_6;
         }

--- a/tests/IPTest.php
+++ b/tests/IPTest.php
@@ -438,6 +438,7 @@ class IPTest extends \PHPUnit_Framework_TestCase
             // And finally, just check that it can properly detect a version 4
             // address in version 4/6 notation.
             array('::0:12.34.56.78', IP::VERSION_4),
+            array('::ffff:7f00:1', IP::VERSION_4),
         );
     }
 


### PR DESCRIPTION
The format `::7f00:1` (`::127.0.0.1`) is deprecated in favour of adding 2 bytes of 1's in-front of the version 4 address (`::ffff:7f00:1` or `::ffff:127.0.0.1`). Update the getVersion() to check for this nibble of 1's when checking if the IP address is version 4 or not.

This fixes #14.