### PR TITLE
Add Methods for IPv4-in-IPv6 notation to Public API

### DIFF
--- a/src/IP.php
+++ b/src/IP.php
@@ -239,6 +239,27 @@ class IP
     }
 
     /**
+     * Whether the IP is an IPv4-mapped IPv6 address (eg, "::ffff:7f00:1").
+     *
+     * @return bool
+     */
+    public function isMapped()
+    {
+        return $this->inRange(new IP('::ffff:0:0'), 96);
+    }
+
+    /**
+     * Whether the IP is a 6to4-derived address (eg, "2002:7f00:1::").
+     *
+     * @return bool
+     */
+    public function isDerived()
+    {
+        return substr($this->ip, 0, 2) === pack('H*', '2002')
+            && substr($this->ip, 6) === "\0\0\0\0\0\0\0\0\0\0";
+    }
+
+    /**
      * Whether the IP is reserved for link-local usage according to RFC 3927/RFC 4291 (IPv4/IPv6)
      *
      * @return bool

--- a/tests/IPTest.php
+++ b/tests/IPTest.php
@@ -527,6 +527,59 @@ class IPTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($ip->isVersion6());
     }
 
+    public function ipAddressesMapped()
+    {
+        return array(
+            array('::ffff:7f00:1', true),
+            array('::ffff:1234:5678', true),
+            array('0000:0000:0000:0000:0000:ffff:7f00:a001', true),
+            array('::fff:7f00:1', false),
+            array('a::ffff:7f00:1', false),
+            array('2001:db8::a60:8a2e:370:7334', false),
+        );
+    }
+
+    /**
+     * Test: Is Mapped?
+     *
+     * @test
+     * @dataProvider ipAddressesMapped
+     * @param string $ip
+     * @param bool $isMapped
+     */
+    public function isMapped($ip, $isMapped)
+    {
+        $ip = new IP($ip);
+        $this->assertSame($isMapped, $ip->isMapped());
+    }
+
+    public function ipAddressesDerived()
+    {
+        return array(
+            array('2002::', true),
+            array('2002:7f00:1::', true),
+            array('2002:1234:4321:0:00:000:0000::', true),
+            array('2001:7f00:1::', false),
+            array('2002:7f00:1::a', false),
+            array('127.0.0.1', false),
+        );
+    }
+
+    /**
+     * Test: Is Derived
+     *
+     * @test
+     * @dataProvider ipAddressesDerived
+     * @access public
+     * @param string $ip
+     * @param bool $isDerived
+     */
+    public function isDerived($ip, $isDerived)
+    {
+        $ip = new IP($ip);
+        $this->assertSame($isDerived, $ip->isDerived());
+    }
+
     /**
      * Data Provider: Link Local IP Addresses
      *


### PR DESCRIPTION
Add two methods to the public API for detecting if an address is IPv4 in IPv6 notation:
- `isMapped()` for IPv4-mapped IPv6 addresses.
- `isDerived()` for  IPv4-mapped IPv6 addresses.

This is the first, backwards-compatible part to issue #17.