### PR TITLE
Public API: detect IPv4 compatible and embedded IPv6 addresses

### DIFF
--- a/src/IP.php
+++ b/src/IP.php
@@ -201,7 +201,7 @@ class IP
     {
         if ($this->version === null) {
             $this->version = strpos($binary = $this->getBinary(), str_repeat($nibble = "\0\0", 5)) === 0
-                && in_array(substr($binary, 10, 2), [$nibble, ~$nibble], true)
+            && in_array(substr($binary, 10, 2), [$nibble, ~$nibble], true)
                 ? self::VERSION_4
                 : self::VERSION_6;
         }
@@ -256,8 +256,29 @@ class IP
      */
     public function isDerived()
     {
-        return substr($this->ip, 0, 2) === pack('H*', '2002')
-            && substr($this->ip, 6) === "\0\0\0\0\0\0\0\0\0\0";
+        return substr($this->getBinary(), 0, 2) === pack('H*', '2002')
+            && substr($this->getBinary(), 6) === "\0\0\0\0\0\0\0\0\0\0";
+    }
+
+    /**
+     * Whether the IP is an IPv4-compatible IPv6 address (eg, `::7f00:1`).
+     *
+     * @return bool
+     */
+    public function isCompatible()
+    {
+        return substr($this->getBinary(), 0, 12) === "\0\0\0\0\0\0\0\0\0\0\0\0";
+    }
+
+    /**
+     * Whether the IP is an IPv4-embedded IPv6 address (either a mapped or
+     * compatible address).
+     *
+     * @return bool
+     */
+    public function isEmbedded()
+    {
+        return $this->isCompatible() || $this->isMapped();
     }
 
     /**
@@ -269,8 +290,7 @@ class IP
     {
         return
             $this->inRange(new IP('169.254.0.0'), self::CIDR4TO6 + 16) ||
-            $this->inRange(new IP('fe80::'), 10)
-        ;
+            $this->inRange(new IP('fe80::'), 10);
     }
 
     /**

--- a/tests/IPTest.php
+++ b/tests/IPTest.php
@@ -570,7 +570,6 @@ class IPTest extends \PHPUnit_Framework_TestCase
      *
      * @test
      * @dataProvider ipAddressesDerived
-     * @access public
      * @param string $ip
      * @param bool $isDerived
      */
@@ -578,6 +577,58 @@ class IPTest extends \PHPUnit_Framework_TestCase
     {
         $ip = new IP($ip);
         $this->assertSame($isDerived, $ip->isDerived());
+    }
+
+    public function ipAddressesCompatible()
+    {
+        return array(
+            array('::7f00:1', true),
+            array('127.0.0.1', true),
+            array('2002:7f00:1::', false),
+        );
+    }
+
+    /**
+     * Test: Is Compatible
+     *
+     * @test
+     * @dataProvider ipAddressesCompatible
+     * @param string $ip
+     * @param bool $isCompatible
+     */
+    public function isCompatible($ip, $isCompatible)
+    {
+        $ip = new IP($ip);
+        $this->assertSame($isCompatible, $ip->isCompatible());
+    }
+
+    public function ipAddressesEmbedded()
+    {
+        return array(
+            array('::ffff:7f00:1', true),
+            array('::ffff:1234:5678', true),
+            array('0000:0000:0000:0000:0000:ffff:7f00:a001', true),
+            array('::fff:7f00:1', false),
+            array('a::ffff:7f00:1', false),
+            array('2001:db8::a60:8a2e:370:7334', false),
+            array('::7f00:1', true),
+            array('127.0.0.1', true),
+            array('2002:7f00:1::', false),
+        );
+    }
+
+    /**
+     * Test: Is Embedded
+     *
+     * @test
+     * @dataProvider ipAddressesEmbedded
+     * @param $ip
+     * @param $isEmbedded
+     */
+    public function isEmbedded($ip, $isEmbedded)
+    {
+        $ip = new IP($ip, $isEmbedded);
+        $this->assertSame($isEmbedded, $ip->isEmbedded());
     }
 
     /**


### PR DESCRIPTION
Add `isCompatible()` and `isEmbedded()` for detecting IPv4 compatible and embedded IPv6 addresses.