### PR TITLE
Update Public API Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ ranges from 0 to 128 instead. When working with IPv4 addresses, you must add 96
 to the IPv4 subnet mask (therefore making it an IPv6 subnet mask) to get the
 correct integer to pass to the following methods.
 
+A helper constant, `CIDR4TO6`, has been added to the library to assist with CIDR
+conversions.
+
 ### In Range
 
 ```php
@@ -129,8 +132,8 @@ use Darsyn\IP\IP;
 $hostIp = new IP('::c22:384e');
 $clientIp = new IP('12.48.183.1');
 
-$clientIp->inRange($ip, 96 + 11); // bool(true)
-$clientIp->inRange($ip, 96 + 24); // bool(false)
+$clientIp->inRange($ip, IP::CIDR4TO6 + 11); // bool(true)
+$clientIp->inRange($ip, IP::CIDR4TO6 + 24); // bool(false)
 ```
 
 ### Network IP
@@ -141,7 +144,7 @@ use Darsyn\IP\IP;
 
 $ip = new IP('12.34.56.78');
 // Get the network address of an IP address given a subnet mask.
-$networkIp = $ip->getNetworkIP(96 + 19);
+$networkIp = $ip->getNetworkIP(IP::CIDR4TO6 + 19);
 $networkIp->getShortAddress(); // string() "12.34.32.0"
 ```
 
@@ -153,7 +156,7 @@ use Darsyn\IP\IP;
 
 $ip = new IP('12.34.56.78');
 // Get the broadcast address of an IP address given a subnet mask.
-$broadcastIp = $ip->getBroadcastIp(96 + 19);
+$broadcastIp = $ip->getBroadcastIp(IP::CIDR4TO6 + 19);
 $broadcastIp->getShortAddress(); // string() "12.34.63.255"
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $ip->isVersion4();             // bool(true)
 $ip->isVersion6();             // bool(false)
 ```
 
-## IP Return Formats.
+## IP Return Formats
 
 Once an object has been instantiated, the value can be returned as either long,
 short or binary notation.
@@ -181,7 +181,7 @@ $ip->isMapped(); // bool(true)
 
 #### Derived
 
-Whether the IP is an 6to4-derived IPv6 address (eg, `2002:7f00:1::`) according
+Whether the IP is a 6to4-derived IPv6 address (eg, `2002:7f00:1::`) according
 to [RFC 3056](https://tools.ietf.org/html/rfc3056
 "Connection of IPv6 Domains via IPv4 Clouds").
 
@@ -196,7 +196,7 @@ $ip->isDerived(); // bool(true)
 #### Compatible
 
 Whether the IP is an IPv4-compatible IPv6 address (eg, `::7f00:1`) according to
-[RFC 4291](https://tools.ietf.org/html/rfc4291.html#section-2.5.5.1]
+[RFC 4291](https://tools.ietf.org/html/rfc4291.html#section-2.5.5.1
 "IP Version 6 Addressing Architecture").
 
 > IPv4-compatible IPv6 addresses are deprecated in the RFC.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,65 @@ $broadcastIp->getShortAddress(); // string() "12.34.63.255"
 The type methods return a boolean value depending on whether the IP address is a
 certain type.
 
+#### Mapped
+
+Whether the IP is an IPv4-mapped IPv6 address (eg, `::ffff:7f00:1`) according to
+[RFC 4291](https://tools.ietf.org/html/rfc4291#section-2.5.5.2
+"IP Version 6 Addressing Architecture").
+
+```php
+<?php
+use Darsyn\IP\IP;
+
+$ip = new IP('::ffff:7f00:1');
+$ip->isMapped(); // bool(true)
+```
+
+#### Derived
+
+Whether the IP is an 6to4-derived IPv6 address (eg, `2002:7f00:1::`) according
+to [RFC 3056](https://tools.ietf.org/html/rfc3056
+"Connection of IPv6 Domains via IPv4 Clouds").
+
+```php
+<?php
+use Darsyn\IP\IP;
+
+$ip = new IP('2002:7f00:1::');
+$ip->isDerived(); // bool(true)
+```
+
+#### Compatible
+
+Whether the IP is an IPv4-compatible IPv6 address (eg, `::7f00:1`) according to
+[RFC 4291](https://tools.ietf.org/html/rfc4291.html#section-2.5.5.1]
+"IP Version 6 Addressing Architecture").
+
+> IPv4-compatible IPv6 addresses are deprecated in the RFC.
+
+```php
+<?php
+use Darsyn\IP\IP;
+
+$ip = new IP('::7f00:1');
+$ip->isCompatible(); // bool(true)
+```
+
+#### Embedded
+
+Whether the IP is an IPv4-embedded IPv6 address (either a mapped or compatible
+address) according to
+[RFC 4291](https://tools.ietf.org/html/rfc4291.html#section-2.5.5
+"IP Version 6 Addressing Architecture").
+
+```php
+<?php
+use Darsyn\IP\IP;
+
+$ip = new IP('::ffff:7f00:1');
+$ip->isEmbedded(); // bool(true)
+```
+
 #### Link Local
 
 Whether the IP is reserved for link-local usage according to

--- a/src/IP.php
+++ b/src/IP.php
@@ -5,14 +5,14 @@ namespace Darsyn\IP;
 /**
  * IP Address
  *
- * IP is an immutable value object that provides several notations of the same IP
- * value, including some helper functions for broadcast and network addresses,
- * and whether its within the range of another IP address according to a CIDR
- * (subnet mask).
+ * IP is an immutable value object that provides several notations of the same
+ * IP value, including some helper functions for broadcast and network
+ * addresses, and whether its within the range of another IP address according
+ * to a CIDR (subnet mask).
  * Although it deals with both IPv4 and IPv6 notations, it makes no distinction
  * between the two protocol formats as it converts both of them to a 16-byte
- * binary sequence for easy mathematical operations and consistency (for example,
- * storing both IPv4 and IPv6 in the same column in a database).
+ * binary sequence for easy mathematical operations and consistency (for
+ * example, storing both IPv4 and IPv6 in the same column in a database).
  *
  * @author      Zander Baldwin <hello@zanderbaldwin.com>
  * @link        https://github.com/darsyn/ip
@@ -53,8 +53,9 @@ class IP
             $ip = current(unpack('a16', inet_pton($ip)));
         }
         if (!is_string($ip) || $this->getIpLength($ip) !== 16) {
-            // If the string was not 16-bytes long, then the IP supplied was neither
-            // in protocol notation or binary sequence notation. Throw an exception.
+            // If the string was not 16-bytes long, then the IP supplied was
+            // neither in protocol notation or binary sequence notation. Throw
+            // an exception.
             throw new InvalidIpAddressException($ip);
         }
         $this->ip = $ip;
@@ -72,8 +73,8 @@ class IP
     /**
      * Get Short Address
      *
-     * Converts an IP address into the smallest protocol notation it can; dot-notation
-     * for IPv4, and compacted (double colons) notation for IPv6.
+     * Converts an IP address into the smallest protocol notation it can;
+     * dot-notation for IPv4, and compacted (double colons) notation for IPv6.
      *
      * @return string
      */
@@ -89,14 +90,15 @@ class IP
     /**
      * Get Long Address
      *
-     * Converts an IP (regardless of version) address into a full IPv6 address (no
-     * double colons).
+     * Converts an IP (regardless of version) address into a full IPv6 address
+     * (no double colons).
      *
      * @return string
      */
     public function getLongAddress()
     {
-        // Convert the 16-byte binary sequence into a hexadecimal-string representation.
+        // Convert the 16-byte binary sequence into a hexadecimal-string
+        // representation.
         $hex = unpack('H*hex', $this->getBinary());
         // Insert a colon between every block of 4 characters, and return the
         // resulting IP address in full IPv6 protocol notation.
@@ -127,20 +129,23 @@ class IP
         if (!is_int($cidr) || $cidr < 0 || $cidr > 128) {
             throw new \InvalidArgumentException('CIDR must be an integer between 0 and 128.');
         }
-        // Since it takes 4 bits per hexadecimal, how many sections of complete 1's do we have (f's)?
+        // Since it takes 4 bits per hexadecimal, how many sections of complete
+        // 1's do we have (f's)?
         $mask = str_repeat('f', floor($cidr / 4));
-        // Now we have less than four 1 bits left we need to determine what hexadecimal
-        // character should be added next. Of course, we should only add them in
-        // there are 1 bits leftover to prevent going over the 128-bit limit.
+        // Now we have less than four 1 bits left we need to determine what
+        // hexadecimal character should be added next. Of course, we should only
+        // add them in there are 1 bits leftover to prevent going over the
+        // 128-bit limit.
         if ($bits = $cidr % 4) {
-            // Create a string representation of a 4-bit binary sequence beginning
-            // with the amount of leftover 1's.
+            // Create a string representation of a 4-bit binary sequence
+            // beginning with the amount of leftover 1's.
             $bin = str_pad(str_repeat('1', $bits), 4, '0', STR_PAD_RIGHT);
             // Convert that 4-bit binary string into a hexadecimal character,
             // and append it to the mask.
             $mask .= dechex(bindec($bin));
         }
-        // Fill the rest of the string up with zero's to pad it out to the correct length.
+        // Fill the rest of the string up with zero's to pad it out to the
+        // correct length.
         $mask = str_pad($mask, 32, '0', STR_PAD_RIGHT);
         // Pack the hexadecimal sequence into a real, 16-byte binary sequence.
         $mask = pack('H*', $mask);
@@ -282,7 +287,8 @@ class IP
     }
 
     /**
-     * Whether the IP is reserved for link-local usage according to RFC 3927/RFC 4291 (IPv4/IPv6)
+     * Whether the IP is reserved for link-local usage according to
+     * RFC 3927/RFC 4291 (IPv4/IPv6).
      *
      * @return bool
      */
@@ -294,7 +300,8 @@ class IP
     }
 
     /**
-     * Whether the IP is a loopback address according to RFC 2373/RFC 3330 (IPv4/IPv6)
+     * Whether the IP is a loopback address according to RFC 2373/RFC 3330
+     * (IPv4/IPv6).
      *
      * @return bool
      */
@@ -305,7 +312,8 @@ class IP
     }
 
     /**
-     * Whether the IP is a multicast address according to RFC 3171/RFC 2373 (IPv4/IPv6)
+     * Whether the IP is a multicast address according to RFC 3171/RFC 2373
+     * (IPv4/IPv6).
      *
      * @return bool
      */
@@ -316,7 +324,8 @@ class IP
     }
 
     /**
-     * Whether the IP is for private use according to RFC 1918/RFC 4193 (IPv4/IPv6)
+     * Whether the IP is for private use according to RFC 1918/RFC 4193
+     * (IPv4/IPv6).
      *
      * @return bool
      */
@@ -329,7 +338,7 @@ class IP
     }
 
     /**
-     * Whether the IP is unspecified according to RFC 5735/RFC 2373 (IPv4/IPv6)
+     * Whether the IP is unspecified according to RFC 5735/RFC 2373 (IPv4/IPv6).
      *
      * @return bool
      */

--- a/src/IP.php
+++ b/src/IP.php
@@ -67,6 +67,8 @@ class IP
      */
     private function getIpLength($ip)
     {
+        // Don't use strlen() directly to prevent incorrect lengths resulting
+        // from null bytes.
         return strlen(bin2hex($ip)) / 2;
     }
 


### PR DESCRIPTION
Add documentation for:
- The methods `isMapped()`, `isDerived()`, `isEmbedded()` and `isCompatible()`.
- The helper constant `CIDR4TO6`.

Fixes #20.