### PR TITLE
Update Library Exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ dependency on the in-built PHP functions `inet_pton` and `int_ntop`.
 ## Instantiation
 
 IP addresses get automatically validated on object instantiation; if the IP
-address supplied is invalid, an [`InvalidIpAddressException`](src/InvalidIpAddressException.php)
+address supplied is invalid, an [`InvalidIpAddressException`](src/Exception/InvalidIpAddressException.php)
 will be thrown.
 
 ```php

--- a/src/Doctrine/IpType.php
+++ b/src/Doctrine/IpType.php
@@ -2,7 +2,7 @@
 
 namespace Darsyn\IP\Doctrine;
 
-use Darsyn\IP\InvalidIpAddressException;
+use Darsyn\IP\Exception\InvalidIpAddressException;
 use Darsyn\IP\IP;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;

--- a/src/Exception/InvalidCidrException.php
+++ b/src/Exception/InvalidCidrException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Darsyn\IP\Exception;
+
+class InvalidCidrException extends \InvalidArgumentException
+{
+    private $cidr;
+
+    public function __construct($cidr, \Exception $previous = null)
+    {
+        $this->cidr = $cidr;
+        $message = is_int($cidr)
+            ? 'The CIDR supplied is not valid; it must be between 0 and 128.'
+            : 'The CIDR supplied is not valid; it must be an integer between 0 and 128.';
+        parent::__construct($message, null, $previous);
+    }
+
+    public function getSuppliedCidr()
+    {
+        return $this->cidr;
+    }
+}

--- a/src/Exception/InvalidIpAddressException.php
+++ b/src/Exception/InvalidIpAddressException.php
@@ -1,15 +1,11 @@
 <?php
 
-namespace Darsyn\IP;
+namespace Darsyn\IP\Exception;
 
 class InvalidIpAddressException extends \InvalidArgumentException
 {
     private $ip;
 
-    /**
-     * @param string $ip
-     * @param \Exception $previous
-     */
     public function __construct($ip, \Exception $previous = null)
     {
         $this->ip = $ip;
@@ -19,10 +15,7 @@ class InvalidIpAddressException extends \InvalidArgumentException
         parent::__construct($message, null, $previous);
     }
 
-    /**
-     * @return string
-     */
-    public function getIp()
+    public function getSuppliedIp()
     {
         return $this->ip;
     }

--- a/src/IP.php
+++ b/src/IP.php
@@ -2,6 +2,8 @@
 
 namespace Darsyn\IP;
 
+use Darsyn\IP\Exception;
+
 /**
  * IP Address
  *
@@ -40,7 +42,7 @@ class IP
      *
      * @access public
      * @param  string $ip
-     * @throws \Darsyn\IP\InvalidIpAddressException
+     * @throws \Darsyn\IP\Exception\InvalidIpAddressException
      */
     public function __construct($ip)
     {
@@ -56,7 +58,7 @@ class IP
             // If the string was not 16-bytes long, then the IP supplied was
             // neither in protocol notation or binary sequence notation. Throw
             // an exception.
-            throw new InvalidIpAddressException($ip);
+            throw new Exception\InvalidIpAddressException($ip);
         }
         $this->ip = $ip;
     }
@@ -129,7 +131,7 @@ class IP
     protected function getMask($cidr)
     {
         if (!is_int($cidr) || $cidr < 0 || $cidr > 128) {
-            throw new \InvalidArgumentException('CIDR must be an integer between 0 and 128.');
+            throw new Exception\InvalidCidrException($cidr);
         }
         // Since it takes 4 bits per hexadecimal, how many sections of complete
         // 1's do we have (f's)?

--- a/tests/IPTest.php
+++ b/tests/IPTest.php
@@ -2,7 +2,7 @@
 
 namespace Darsyn\IP\Tests;
 
-use Darsyn\IP\InvalidIpAddressException;
+use Darsyn\IP\Exception;
 use Darsyn\IP\IP;
 use PHPUnit_Framework_TestCase as TestCase;
 
@@ -78,15 +78,15 @@ class IPTest extends TestCase
 
     /**
      * @test
-     * @expectedException \Darsyn\IP\InvalidIpAddressException
+     * @expectedException \Darsyn\IP\Exception\InvalidIpAddressException
      * @dataProvider dataProviderInvalidIpAddresses
      */
     public function testExceptionThrownWhenInvalidIpSuppliedDuringInstantiation($ipAddress)
     {
         try {
             new IP($ipAddress);
-        } catch (InvalidIpAddressException $e) {
-            $this->assertSame($ipAddress, $e->getIp());
+        } catch (Exception\InvalidIpAddressException $e) {
+            $this->assertSame($ipAddress, $e->getSuppliedIp());
             throw $e;
         }
         $this->fail();
@@ -151,7 +151,7 @@ class IPTest extends TestCase
     /**
      * @test
      * @dataProvider dataProviderInvalidCidrValues
-     * @expectedException \InvalidArgumentException
+     * @expectedException \Darsyn\IP\Exception\InvalidCidrException
      */
     public function testInvalidCidrValues($cidr)
     {
@@ -159,7 +159,14 @@ class IPTest extends TestCase
         $method = $class->getMethod('getMask');
         $method->setAccessible(true);
         $ip = new IP('12.34.56.78');
-        $method->invoke($ip, $cidr);
+
+        try {
+            $method->invoke($ip, $cidr);
+        } catch (Exception\InvalidCidrException $e) {
+            $this->assertSame($cidr, $e->getSuppliedCidr());
+            throw $e;
+        }
+        $this->fail();
     }
 
     public function dataProviderValidNetworkAddressesVersion4()


### PR DESCRIPTION
A library should not throw any root-namespace exceptions.
All exceptions thrown from this library are now library-level to allow users to fine-grain their exception handling.