### PR TITLE
Upgrade Codebase to PHP 7.1+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /build/
 /.idea/
+/var/
 /vendor/
 # Because this library will never be the root package, don't commit Composer's lock file.
 /composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
 language: php
 php:
-    - '5.6'
-    - '7.0'
     - '7.1'
     - '7.2'
+    - '7.3'
     - 'hhvm'
 
 matrix:
     allow_failures:
         - php: hhvm
 
-install:
-    - composer install
 script:
-    - ./vendor/bin/phpunit
+    - make test
 
 sudo: false

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+P := "$$(tput setaf 2)"
+S := "$$(tput setaf 4)"
+L := "$$(tput setaf 6)"
+R := "$$(tput sgr0)"
+usage:
+	@echo ""
+	@echo " $(L)┏━━━━━━━━━━━━━━━━━━━━━┓$(R)"
+	@echo " $(L)┃   $(R)Darsyn IP$(L)         ┃$(R)"
+	@echo " $(L)┡━━━━━━━━━━━━━━━━━━━━━┩$(R)"
+	@echo " $(L)│ $(R)Available Commands:$(L) │$(R)"
+	@echo " $(L)╰─┬───────────────────╯$(R)"
+	@echo "   $(L)├─$(R) $(P)install$(R)           Install third-party dependencies."
+	@echo "   $(L)╰─$(R) $(P)test$(R)              Run all of the following tests:"
+	@echo "      $(L)├─$(R) $(S)unit$(R)           • Run PHPUnit tests."
+	@echo "      $(L)╰─$(R) $(S)cs$(R)             • Run check PHP code for linting and syntax errors."
+	@echo ""
+	@echo "   $(L)╭$(R)                                           $(L)╮$(R)"
+	@echo "   $(L)│$(R) Performs basic shortcuts; use $(P)vendor/bin/$(R) $(L)│$(R)"
+	@echo "   $(L)│$(R) executables for advanced usage.           $(L)│$(R)"
+	@echo "   $(L)╰$(R)                                           $(L)╯$(R)"
+	@echo ""
+
+MKFILE := $(abspath $(lastword $(MAKEFILE_LIST)))
+MKDIR  := $(dir $(MKFILE))
+
+# Composer Dependencies
+vendor/autoload.php:
+	composer install
+
+# Commonly-used PHP Scripts
+bin/phpunit: vendor/autoload.php
+bin/phpcs: vendor/autoload.php
+
+# Shortcuts
+install: vendor/autoload.php
+up: composer keys
+	docker-compose up -d
+test: cs unit
+# Specific Types of Tests
+cs: bin/phpcs
+	"$(MKDIR)/vendor/bin/phpcs" --standard="$(MKDIR)/phpcs.xml" src
+unit: bin/phpunit
+	[ -f "var/xdebug-filter.php" ] || "$(MKDIR)/vendor/bin/phpunit" -c "$(MKDIR)/phpunit.xml" --dump-xdebug-filter "var/xdebug-filter.php"
+	"$(MKDIR)/vendor/bin/phpunit" -c "$(MKDIR)/phpunit.xml" --prepend "var/xdebug-filter.php" --order-by=random --resolve-dependencies
+
+.PHONY: usage install test cs unit

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         }
     },
     "require": {
-        "php-ipv6": ">=5.6",
-        "php-64bit": ">=5.6"
+        "php-ipv6": ">=7.1",
+        "php-64bit": ">=7.1"
     },
     "autoload-dev": {
         "psr-4": {
@@ -28,7 +28,11 @@
     },
     "require-dev": {
         "doctrine/dbal": "^2.3",
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^7.5",
+        "object-calisthenics/phpcs-calisthenics-rules": "^3.1",
+        "roave/security-advisories": "dev-master",
+        "slevomat/coding-standard": "^4.5",
+        "squizlabs/php_codesniffer": "^3.4"
     },
     "prefer-stable": true,
     "config": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="Darsyn IP Coding Standards">
+    <rule ref="PSR2" />
+    <config name="installed_paths" value="../../slevomat/coding-standard"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <properties>
+            <property name="newlinesCountBetweenOpenTagAndDeclare" value="0" />
+            <property name="newlinesCountAfterDeclare" value="2" />
+            <property name="spacesCountAroundEqualsSign" value="0" />
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEqualOperators" />
+    <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma" />
+    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses" />
+    <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse" />
+    <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine" />
+    <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash" />
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+        <properties>
+            <property name="searchAnnotations" value="true" />
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.PHP.TypeCast" />
+    <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility" />
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing" />
+    <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing" />
+</ruleset>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,11 +13,12 @@
         </testsuite>
     </testsuites>
 
-    <!-- Logging. -->
+    <!-- Logging.
     <logging>
         <log type="coverage-html" target="build/coverage/" charset="UTF-8" highlight="true" lowUpperBound="60" highLowerBound="85" />
         <log type="coverage-clover" target="build/coverage.xml" />
     </logging>
+    -->
 
     <!-- Coverage filters. -->
     <filter>

--- a/src/Binary.php
+++ b/src/Binary.php
@@ -1,39 +1,24 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP;
 
 class Binary
 {
-    /**
-    * @param string $str
-    * @return integer
-    */
-    public static function getLength($str)
+    public static function getLength($str): int
     {
         return \function_exists('\\mb_strlen')
             ? (int) \mb_strlen($str, '8bit')
-            : \strlen(\bin2hex($str)) / 2;
+            : (int) (\strlen(\bin2hex($str)) / 2);
     }
 
-    /**
-     * @param string $str
-     * @param integer $start
-     * @param integer|null $length
-     * @return boolean|string
-     */
-    public static function subString($str, $start, $length = null)
+    public static function subString(string $str, int $start, ?int $length = null): string
     {
         return \function_exists('\\mb_substr')
             ? \mb_substr($str, $start, $length, '8bit')
             : \substr($str, $start, $length);
     }
 
-    /**
-    * @param string $hex
-    * @throws \InvalidArgumentException
-    * @return string
-    */
-    public static function fromHex($hex)
+    public static function fromHex(string $hex): string
     {
         if (!\is_string($hex) || !\ctype_xdigit($hex) || static::getLength($hex) % 2 !== 0) {
             throw new \InvalidArgumentException('Valid hexadecimal string not provided.');
@@ -41,15 +26,8 @@ class Binary
         return \pack('H*', \strtolower($hex));
     }
 
-    /**
-    * @param string $binary
-    * @return string
-    */
-    public static function toHex($binary)
+    public static function toHex(string $binary): string
     {
-        if (!\is_string($binary)) {
-            throw new \InvalidArgumentException('Cannot convert non-string to hexidecimal.');
-        }
         $data = \unpack('H*', $binary);
         return \reset($data);
     }

--- a/src/Doctrine/IPv4Type.php
+++ b/src/Doctrine/IPv4Type.php
@@ -1,7 +1,8 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Doctrine;
 
+use Darsyn\IP\IpInterface;
 use Darsyn\IP\Version\IPv4 as IP;
 
 /**
@@ -9,20 +10,14 @@ use Darsyn\IP\Version\IPv4 as IP;
  */
 class IPv4Type extends AbstractType
 {
-    const IP_LENGTH = 4;
+    protected const IP_LENGTH = 4;
 
-    /**
-     * {@inheritDoc}
-     */
-    protected function getIpClass()
+    protected function getIpClass(): string
     {
         return IP::class;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    protected function createIpObject($ip)
+    protected function createIpObject(string $ip): IpInterface
     {
         return IP::factory($ip);
     }

--- a/src/Doctrine/IPv6Type.php
+++ b/src/Doctrine/IPv6Type.php
@@ -1,7 +1,8 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Doctrine;
 
+use Darsyn\IP\IpInterface;
 use Darsyn\IP\Version\IPv6 as IP;
 
 /**
@@ -9,18 +10,12 @@ use Darsyn\IP\Version\IPv6 as IP;
  */
 class IPv6Type extends AbstractType
 {
-    /**
-     * {@inheritDoc}
-     */
-    protected function getIpClass()
+    protected function getIpClass(): string
     {
         return IP::class;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    protected function createIpObject($ip)
+    protected function createIpObject(string $ip): IpInterface
     {
         return IP::factory($ip);
     }

--- a/src/Doctrine/MultiType.php
+++ b/src/Doctrine/MultiType.php
@@ -1,7 +1,8 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Doctrine;
 
+use Darsyn\IP\IpInterface;
 use Darsyn\IP\Version\Multi as IP;
 
 /**
@@ -9,18 +10,12 @@ use Darsyn\IP\Version\Multi as IP;
  */
 class MultiType extends AbstractType
 {
-    /**
-     * {@inheritDoc}
-     */
-    protected function getIpClass()
+    protected function getIpClass(): string
     {
         return IP::class;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    protected function createIpObject($ip)
+    protected function createIpObject(string $ip): IpInterface
     {
         return IP::factory($ip);
     }

--- a/src/Exception/Formatter/FormatException.php
+++ b/src/Exception/Formatter/FormatException.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Exception\Formatter;
 
@@ -9,20 +9,17 @@ class FormatException extends IpException
     /** @var string $binary */
     private $binary;
 
-    /**
-     * @param string $binary
-     * @param \Exception|null $previous
-     */
-    public function __construct($binary, \Exception $previous = null)
+    public function __construct(string $binary, ?\Throwable $previous = null)
     {
         $this->binary = $binary;
-        parent::__construct('Cannot format invalid binary sequence; must be a string either 4 or 16 bytes long.', null, $previous);
+        parent::__construct(
+            'Cannot format invalid binary sequence; must be a string either 4 or 16 bytes long.',
+            0,
+            $previous
+        );
     }
 
-    /**
-     * @return string
-     */
-    public function getSuppliedBinary()
+    public function getSuppliedBinary(): string
     {
         return $this->binary;
     }

--- a/src/Exception/InvalidCidrException.php
+++ b/src/Exception/InvalidCidrException.php
@@ -1,32 +1,22 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Exception;
 
 class InvalidCidrException extends IpException
 {
-    /** @var mixed $cidr */
+    /** @var integer $cidr */
     private $cidr;
 
-    /**
-     * Constructor
-     * .
-     * @param int $cidr
-     * @param int $length
-     * @param \Exception|null $previous
-     */
-    public function __construct($cidr, $length, \Exception $previous = null)
+    public function __construct(int $cidr, int $length, ?\Throwable $previous = null)
     {
         $this->cidr = $cidr;
-        $message = \is_int($length)
-            ? \sprintf('The CIDR supplied is not valid; it must be an integer between 0 and %d.', $length * 8)
-            : 'The CIDR supplied is not valid; it must be an integer.';
-        parent::__construct($message, null, $previous);
+        parent::__construct(\sprintf(
+            'The CIDR supplied is not valid; it must be an integer between 0 and %d.',
+            $length * 8
+        ), 0, $previous);
     }
 
-    /**
-     * @return mixed
-     */
-    public function getSuppliedCidr()
+    public function getSuppliedCidr(): int
     {
         return $this->cidr;
     }

--- a/src/Exception/InvalidIpAddressException.php
+++ b/src/Exception/InvalidIpAddressException.php
@@ -1,28 +1,19 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Exception;
 
 class InvalidIpAddressException extends IpException
 {
-    /** @var mixed $ip */
+    /** @var string $ip */
     private $ip;
 
-    /**
-     * Constructor
-     *
-     * @param string $ip
-     * @param \Exception|null $previous
-     */
-    public function __construct($ip, \Exception $previous = null)
+    public function __construct(string $ip, ?\Throwable $previous = null)
     {
         $this->ip = $ip;
-        parent::__construct('The IP address supplied is not valid.', null, $previous);
+        parent::__construct('The IP address supplied is not valid.', 0, $previous);
     }
 
-    /**
-     * @return mixed
-     */
-    public function getSuppliedIp()
+    public function getSuppliedIp(): string
     {
         return $this->ip;
     }

--- a/src/Exception/IpException.php
+++ b/src/Exception/IpException.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Exception;
 

--- a/src/Exception/Strategy/ExtractionException.php
+++ b/src/Exception/Strategy/ExtractionException.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Exception\Strategy;
 
@@ -13,13 +13,11 @@ class ExtractionException extends IpException
     /** @var \Darsyn\IP\Strategy\EmbeddingStrategyInterface $embeddingStrategy */
     private $embeddingStrategy;
 
-    /**
-     * @param string $binary
-     * @param \Darsyn\IP\Strategy\EmbeddingStrategyInterface $embeddingStrategy
-     * @param \Exception|null $previous
-     */
-    public function __construct($binary, EmbeddingStrategyInterface $embeddingStrategy, \Exception $previous = null)
-    {
+    public function __construct(
+        string $binary,
+        EmbeddingStrategyInterface $embeddingStrategy,
+        ?\Throwable $previous = null
+    ) {
         $this->binary = $binary;
         $this->embeddingStrategy = $embeddingStrategy;
         parent::__construct(\sprintf(
@@ -28,18 +26,12 @@ class ExtractionException extends IpException
         ), 0, $previous);
     }
 
-    /**
-     * @return string
-     */
-    public function getSuppliedBinary()
+    public function getSuppliedBinary(): string
     {
         return $this->binary;
     }
 
-    /**
-     * @return \Darsyn\IP\Strategy\EmbeddingStrategyInterface
-     */
-    public function getEmbeddingStrategy()
+    public function getEmbeddingStrategy(): EmbeddingStrategyInterface
     {
         return $this->embeddingStrategy;
     }

--- a/src/Exception/Strategy/PackingException.php
+++ b/src/Exception/Strategy/PackingException.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Exception\Strategy;
 
@@ -13,13 +13,11 @@ class PackingException extends IpException
     /** @var \Darsyn\IP\Strategy\EmbeddingStrategyInterface $embeddingStrategy */
     private $embeddingStrategy;
 
-    /**
-     * @param string $binary
-     * @param EmbeddingStrategyInterface $embeddingStrategy
-     * @param \Exception|null $previous
-     */
-    public function __construct($binary, EmbeddingStrategyInterface $embeddingStrategy, \Exception $previous = null)
-    {
+    public function __construct(
+        string $binary,
+        EmbeddingStrategyInterface $embeddingStrategy,
+        ?\Throwable $previous = null
+    ) {
         $this->binary = $binary;
         $this->embeddingStrategy = $embeddingStrategy;
         parent::__construct(\sprintf(
@@ -28,18 +26,12 @@ class PackingException extends IpException
         ), 0, $previous);
     }
 
-    /**
-     * @return string
-     */
-    public function getSuppliedBinary()
+    public function getSuppliedBinary(): string
     {
         return $this->binary;
     }
 
-    /**
-     * @return \Darsyn\IP\Strategy\EmbeddingStrategyInterface
-     */
-    public function getEmbeddingStrategy()
+    public function getEmbeddingStrategy(): EmbeddingStrategyInterface
     {
         return $this->embeddingStrategy;
     }

--- a/src/Exception/WrongVersionException.php
+++ b/src/Exception/WrongVersionException.php
@@ -1,40 +1,28 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Exception;
 
 class WrongVersionException extends InvalidIpAddressException
 {
-    /** @var int $expected */
+    /** @var integer $expected */
     private $expected;
 
-    /** @var int $actual */
+    /** @var integer $actual */
     private $actual;
 
-    /**
-     * @param int $expected
-     * @param int $actual
-     * @param string $ip
-     * @param \Exception|null $previous
-     */
-    public function __construct($expected, $actual, $ip, \Exception $previous = null)
+    public function __construct(int $expected, int $actual, string $ip, ?\Throwable $previous = null)
     {
         $this->expected = $expected;
         $this->actual = $actual;
         parent::__construct($ip, $previous);
     }
 
-    /**
-     * @return int
-     */
-    public function getExpectedVersion()
+    public function getExpectedVersion(): int
     {
         return $this->expected;
     }
 
-    /**
-     * @return int
-     */
-    public function getActualVersion()
+    public function getActualVersion(): int
     {
         return $this->actual;
     }

--- a/src/Formatter/ConsistentFormatter.php
+++ b/src/Formatter/ConsistentFormatter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Formatter;
 
@@ -7,10 +7,8 @@ use Darsyn\IP\Exception\Formatter\FormatException;
 
 class ConsistentFormatter extends NativeFormatter
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function ntop($binary)
+    /** {@inheritdoc} */
+    public function ntop(string $binary): string
     {
         if (\is_string($binary)) {
             $length = Binary::getLength($binary);
@@ -24,7 +22,7 @@ class ConsistentFormatter extends NativeFormatter
         throw new FormatException($binary);
     }
 
-    private function ntopVersion6($hex)
+    private function ntopVersion6(string $hex): string
     {
         $parts = \str_split($hex, 4);
         $zeroes = \array_map(function ($part) {
@@ -47,8 +45,13 @@ class ConsistentFormatter extends NativeFormatter
         return \str_pad(\preg_replace('/\:{2,}/', '::', \implode(':', $parts)), 2, ':');
     }
 
-    private function ntopVersion4($binary)
+    /** @throws \Darsyn\IP\Exception\Formatter\FormatException */
+    private function ntopVersion4(string $binary): string
     {
-        return \inet_ntop(\pack('A4', $binary));
+        $protocol = \inet_ntop(\pack('A4', $binary));
+        if (!\is_string($protocol)) {
+            throw new FormatException($binary);
+        }
+        return $protocol;
     }
 }

--- a/src/Formatter/NativeFormatter.php
+++ b/src/Formatter/NativeFormatter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Formatter;
 
@@ -7,24 +7,23 @@ use Darsyn\IP\Exception\Formatter\FormatException;
 
 class NativeFormatter implements ProtocolFormatterInterface
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function ntop($binary)
+    /** {@inheritdoc} */
+    public function ntop(string $binary): string
     {
         if (\is_string($binary)) {
             $length = Binary::getLength($binary);
             if ($length === 16 || $length === 4) {
-                return \inet_ntop(\pack('A' . (string) $length, $binary));
+                $protocol = \inet_ntop(\pack('A' . (string) $length, $binary));
+                if (\is_string($protocol)) {
+                    return $protocol;
+                }
             }
         }
         throw new FormatException($binary);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function pton($protocol)
+    /** {@inheritdoc} */
+    public function pton(string $protocol): string
     {
         if (\is_string($protocol)) {
             if (\filter_var($protocol, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4)) {

--- a/src/Formatter/ProtocolFormatterInterface.php
+++ b/src/Formatter/ProtocolFormatterInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Formatter;
 
@@ -7,19 +7,14 @@ interface ProtocolFormatterInterface
     /**
      * Protocol to Binary
      *
-     * @param string $binary
      * @throws \Darsyn\IP\Exception\Formatter\FormatException
-     * @return string
      */
-    public function pton($binary);
+    public function pton(string $binary): string;
 
     /**
      * Binary to Protocol
      *
-     * Convert
-     * @param string $binary
      * @throws \Darsyn\IP\Exception\Formatter\FormatException
-     * @return string
      */
-    public function ntop($binary);
+    public function ntop(string $binary): string;
 }

--- a/src/IpInterface.php
+++ b/src/IpInterface.php
@@ -1,154 +1,94 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP;
 
 interface IpInterface
 {
     /**
-     * @param string $ip
      * @throws \Darsyn\IP\Exception\InvalidIpAddressException
      * @throws \Darsyn\IP\Exception\WrongVersionException
-     * @return static
+     * @return \Darsyn\IP\IpInterface
      */
-    public static function factory($ip);
+    public static function factory(string $ip);
+
+    /** Get Binary Representation */
+    public function getBinary(): string;
+
+    /** Get the IP version from the binary value */
+    public function getVersion(): int;
+
+    public function isVersion(int $version): bool;
+
+    /** Whether the IP is version 4 */
+    public function isVersion4(): bool;
+
+    /** Whether the IP is version 6 */
+    public function isVersion6(): bool;
 
     /**
-     * Get Binary Representation
-     *
-     * @return string
-     */
-    public function getBinary();
-
-    /**
-     * Get the IP version from the binary value
-     *
-     * @return int
-     */
-    public function getVersion();
-
-    /**
-     * Is Version?
-     *
-     * @param int $version
-     * @return bool
-     */
-    public function isVersion($version);
-
-    /**
-     * Whether the IP is version 4
-     *
-     * @return bool
-     */
-    public function isVersion4();
-
-    /**
-     * Whether the IP is version 6
-     *
-     * @return bool
-     */
-    public function isVersion6();
-
-    /**
-     * Get Network Address
-     *
      * Get a new value object from the network address of the original IP.
      *
-     * @param int $cidr
      * @throws \Darsyn\IP\Exception\InvalidCidrException
-     * @return static
      */
-    public function getNetworkIp($cidr);
+    public function getNetworkIp(int $cidr): self;
 
     /**
-     * Get Broadcast Address
-     *
      * Get a new value object from the broadcast address of the original IP.
      *
-     * @param int $cidr
      * @throws \Darsyn\IP\Exception\InvalidCidrException
-     * @return static
      */
-    public function getBroadcastIp($cidr);
+    public function getBroadcastIp(int $cidr): self;
 
     /**
-     * Is IP Address In Range?
-     *
      * Returns a boolean value depending on whether the IP address in question
      * is within the range of the target IP/CIDR combination.
      * Comparing two IP's of different versions will *always* return false.
      *
-     * @param \Darsyn\IP\IpInterface $ip
-     * @param integer $cidr
      * @throws \Darsyn\IP\Exception\InvalidCidrException
-     * @return boolean
      */
-    public function inRange(IpInterface $ip, $cidr);
+    public function inRange(IpInterface $ip, int $cidr): bool;
 
-    /**
-     * Whether the IP is an IPv4-mapped IPv6 address (eg, "::ffff:7f00:1").
-     *
-     * @return bool
-     */
-    public function isMapped();
+    /** Whether the IP is an IPv4-mapped IPv6 address (eg, "::ffff:7f00:1") */
+    public function isMapped(): bool;
 
-    /**
-     * Whether the IP is a 6to4-derived address (eg, "2002:7f00:1::").
-     *
-     * @return bool
-     */
-    public function isDerived();
+    /** Whether the IP is a 6to4-derived address (eg, "2002:7f00:1::") */
+    public function isDerived(): bool;
 
-    /**
-     * Whether the IP is an IPv4-compatible IPv6 address (eg, `::7f00:1`).
-     *
-     * @return bool
-     */
-    public function isCompatible();
+    /** Whether the IP is an IPv4-compatible IPv6 address (eg, `::7f00:1`) */
+    public function isCompatible(): bool;
 
     /**
      * Whether the IP is an IPv4-embedded IPv6 address (either a mapped or
      * compatible address).
-     *
-     * @return bool
      */
-    public function isEmbedded();
+    public function isEmbedded(): bool;
 
     /**
      * Whether the IP is reserved for link-local usage according to
      * RFC 3927/RFC 4291 (IPv4/IPv6).
-     *
-     * @return bool
      */
-    public function isLinkLocal();
+    public function isLinkLocal(): bool;
 
     /**
      * Whether the IP is a loopback address according to RFC 2373/RFC 3330
      * (IPv4/IPv6).
-     *
-     * @return bool
      */
-    public function isLoopback();
+    public function isLoopback(): bool;
 
     /**
      * Whether the IP is a multicast address according to RFC 3171/RFC 2373
      * (IPv4/IPv6).
-     *
-     * @return bool
      */
-    public function isMulticast();
+    public function isMulticast(): bool;
 
     /**
      * Whether the IP is for private use according to RFC 1918/RFC 4193
      * (IPv4/IPv6).
-     *
-     * @return bool
      */
-    public function isPrivateUse();
+    public function isPrivateUse(): bool;
 
     /**
      * Whether the IP is unspecified according to RFC 5735/RFC 2373 (IPv4/IPv6).
-     *
-     * @return bool
      */
-    public function isUnspecified();
+    public function isUnspecified(): bool;
 }

--- a/src/Strategy/Compatible.php
+++ b/src/Strategy/Compatible.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Strategy;
 
@@ -7,19 +7,15 @@ use Darsyn\IP\Exception\Strategy as StrategyException;
 
 class Compatible implements EmbeddingStrategyInterface
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function isEmbedded($binary)
+    /** {@inheritDoc} */
+    public function isEmbedded(string $binary): bool
     {
         return Binary::getLength($binary) === 16
             && Binary::subString($binary, 0, 12) === "\0\0\0\0\0\0\0\0\0\0\0\0";
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function extract($binary)
+    /** {@inheritDoc} */
+    public function extract(string $binary): string
     {
         if (Binary::getLength($binary) === 16) {
             return Binary::subString($binary, 12, 4);
@@ -27,10 +23,8 @@ class Compatible implements EmbeddingStrategyInterface
         throw new StrategyException\ExtractionException($binary, $this);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function pack($binary)
+    /** {@inheritDoc} */
+    public function pack(string $binary): string
     {
         if (Binary::getLength($binary) === 4) {
             return "\0\0\0\0\0\0\0\0\0\0\0\0" . $binary;

--- a/src/Strategy/Derived.php
+++ b/src/Strategy/Derived.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Strategy;
 
@@ -7,20 +7,16 @@ use Darsyn\IP\Exception\Strategy as StrategyException;
 
 class Derived implements EmbeddingStrategyInterface
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function isEmbedded($binary)
+    /** {@inheritDoc} */
+    public function isEmbedded(string $binary): bool
     {
         return Binary::getLength($binary) === 16
             && Binary::subString($binary, 0, 2) === Binary::fromHex('2002')
             && Binary::subString($binary, 6, 10) === "\0\0\0\0\0\0\0\0\0\0";
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function extract($binary)
+    /** {@inheritDoc} */
+    public function extract(string $binary): string
     {
         if (Binary::getLength($binary) === 16) {
             return Binary::subString($binary, 2, 4);
@@ -28,10 +24,8 @@ class Derived implements EmbeddingStrategyInterface
         throw new StrategyException\ExtractionException($binary, $this);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function pack($binary)
+    /** {@inheritDoc} */
+    public function pack(string $binary): string
     {
         if (Binary::getLength($binary) === 4) {
             return Binary::fromHex('2002') . $binary . "\0\0\0\0\0\0\0\0\0\0";

--- a/src/Strategy/EmbeddingStrategyInterface.php
+++ b/src/Strategy/EmbeddingStrategyInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Strategy;
 
@@ -7,29 +7,22 @@ interface EmbeddingStrategyInterface
     /**
      * Checks if the IPv6 binary string supplied contains an IPv4 embedded
      * according to the implemented embedding strategy.
-     *
-     * @param string $binary
-     * @return boolean
      */
-    public function isEmbedded($binary);
+    public function isEmbedded(string $binary): bool;
 
     /**
      * Extract the embedded IPv4 binary string from the IPv6 binary string
      * supplied, according to the implemented embedding strategy.
      *
-     * @param string $binary
      * @throws \Darsyn\IP\Exception\Strategy\ExtractionException
-     * @return string
      */
-    public function extract($binary);
+    public function extract(string $binary): string;
 
     /**
      * Convert the supplied IPv4 binary string into an embedded IPv6 binary
      * string, according to the implemented embedding strategy.
      *
-     * @param string $binary
      * @throws \Darsyn\IP\Exception\Strategy\PackingException
-     * @return string
      */
-    public function pack($binary);
+    public function pack(string $binary): string;
 }

--- a/src/Strategy/Mapped.php
+++ b/src/Strategy/Mapped.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Strategy;
 
@@ -7,19 +7,15 @@ use Darsyn\IP\Exception\Strategy as StrategyException;
 
 class Mapped implements EmbeddingStrategyInterface
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function isEmbedded($binary)
+    /** {@inheritDoc} */
+    public function isEmbedded(string $binary): bool
     {
         return Binary::getLength($binary) === 16
             && Binary::subString($binary, 0, 12) === Binary::fromHex('00000000000000000000ffff');
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function extract($binary)
+    /** {@inheritDoc} */
+    public function extract(string $binary): string
     {
         if (Binary::getLength($binary) === 16) {
             return Binary::subString($binary, 12, 4);
@@ -27,10 +23,8 @@ class Mapped implements EmbeddingStrategyInterface
         throw new StrategyException\ExtractionException($binary, $this);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function pack($binary)
+    /** {@inheritDoc} */
+    public function pack(string $binary): string
     {
         if (Binary::getLength($binary) === 4) {
             return Binary::fromHex('00000000000000000000ffff') . $binary;

--- a/src/Version/IPv4.php
+++ b/src/Version/IPv4.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Version;
 
@@ -28,7 +28,7 @@ class IPv4 extends AbstractIP implements Version4Interface
     /**
      * {@inheritDoc}
      */
-    public static function factory($ip)
+    public static function factory(string $ip): Version4Interface
     {
         try {
             // Convert from protocol notation to binary sequence.
@@ -42,70 +42,72 @@ class IPv4 extends AbstractIP implements Version4Interface
                 }
                 $binary = $ip;
             }
-        } catch(Exception\IpException $e) {
+        } catch (Exception\IpException $e) {
             throw new Exception\InvalidIpAddressException($ip, $e);
         }
         return new static($binary);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getDotAddress()
+    /** {@inheritDoc} */
+    public function getDotAddress(): string
     {
         try {
             return self::getProtocolFormatter()->ntop($this->getBinary());
         } catch (Exception\Formatter\FormatException $e) {
-            throw new Exception\IpException('An unknown error occured internally.', null, $e);
+            throw new Exception\IpException('An unknown error occured internally.', 0, $e);
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getVersion()
+    /** {@inheritDoc} */
+    public function getVersion(): int
     {
         return 4;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function isLinkLocal()
+    /** {@inheritDoc} */
+    public function isLinkLocal(): bool
     {
-        return $this->inRange(new static(Binary::fromHex('a9fe0000')), 16);
+        try {
+            return $this->inRange(new static(Binary::fromHex('a9fe0000')), 16);
+        } catch (Exception\InvalidCidrException $e) {
+            return false;
+        }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function isLoopback()
+    /** {@inheritDoc} */
+    public function isLoopback(): bool
     {
-        return $this->inRange(new static(Binary::fromHex('7f000000')), 8);
+        try {
+            return $this->inRange(new static(Binary::fromHex('7f000000')), 8);
+        } catch (Exception\InvalidCidrException $e) {
+            return false;
+        }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function isMulticast()
+    /** {@inheritDoc} */
+    public function isMulticast(): bool
     {
-        return $this->inRange(new static(Binary::fromHex('e0000000')), 4);
+        try {
+            return $this->inRange(new static(Binary::fromHex('e0000000')), 4);
+        } catch (Exception\InvalidCidrException $e) {
+            return false;
+        }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function isPrivateUse()
+    /** {@inheritDoc} */
+    public function isPrivateUse(): bool
     {
-        return $this->inRange(new static(Binary::fromHex('0a000000')), 8)
-            || $this->inRange(new static(Binary::fromHex('ac100000')), 12)
-            || $this->inRange(new static(Binary::fromHex('c0a80000')), 16);
+        try {
+            return $this->inRange(new static(Binary::fromHex('0a000000')), 8)
+                || $this->inRange(new static(Binary::fromHex('ac100000')), 12)
+                || $this->inRange(new static(Binary::fromHex('c0a80000')), 16);
+        } catch (Exception\InvalidCidrException $e) {
+            return false;
+        }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function isUnspecified()
+    /** {@inheritDoc} */
+    public function isUnspecified(): bool
     {
         return $this->getBinary() === "\0\0\0\0";
     }

--- a/src/Version/IPv6.php
+++ b/src/Version/IPv6.php
@@ -1,11 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Version;
 
 use Darsyn\IP\AbstractIP;
 use Darsyn\IP\Binary;
 use Darsyn\IP\Exception;
-use Darsyn\IP\Formatter\ProtocolFormatterInterface;
 
 /**
  * IPv6 Address
@@ -28,8 +27,9 @@ class IPv6 extends AbstractIP implements Version6Interface
 {
     /**
      * {@inheritDoc}
+     * @return \Darsyn\IP\Version\Version6Interface
      */
-    public static function factory($ip)
+    public static function factory(string $ip)
     {
         try {
             // Convert from protocol notation to binary sequence.
@@ -45,10 +45,8 @@ class IPv6 extends AbstractIP implements Version6Interface
         return new static($binary);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getExpandedAddress()
+    /** {@inheritDoc} */
+    public function getExpandedAddress(): string
     {
         // Convert the 16-byte binary sequence into a hexadecimal-string
         // representation, insert a colon between every block of 4 characters,
@@ -56,62 +54,58 @@ class IPv6 extends AbstractIP implements Version6Interface
         return \substr(\preg_replace('/([a-fA-F0-9]{4})/', '$1:', Binary::toHex($this->getBinary())), 0, -1);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getCompactedAddress()
+    /** {@inheritDoc} */
+    public function getCompactedAddress(): string
     {
         try {
             return self::getProtocolFormatter()->ntop($this->getBinary());
         } catch (Exception\Formatter\FormatException $e) {
-            throw new Exception\IpException('An unknown error occured internally.', null, $e);
+            throw new Exception\IpException('An unknown error occured internally.', 0, $e);
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getVersion()
+    public function getVersion(): int
     {
         return 6;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function isLinkLocal()
+    public function isLinkLocal(): bool
     {
-        return $this->inRange(new self(Binary::fromHex('fe800000000000000000000000000000')), 10);
+        try {
+            return $this->inRange(new self(Binary::fromHex('fe800000000000000000000000000000')), 10);
+        } catch (Exception\InvalidCidrException $e) {
+            return false;
+        }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function isLoopback()
+    public function isLoopback(): bool
     {
-        return $this->inRange(new self(Binary::fromHex('00000000000000000000000000000001')), 128);
+        try {
+            return $this->inRange(new self(Binary::fromHex('00000000000000000000000000000001')), 128);
+        } catch (Exception\InvalidCidrException $e) {
+            return false;
+        }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function isMulticast()
+    public function isMulticast(): bool
     {
-        return $this->inRange(new self(Binary::fromHex('ff000000000000000000000000000000')), 8);
+        try {
+            return $this->inRange(new self(Binary::fromHex('ff000000000000000000000000000000')), 8);
+        } catch (Exception\InvalidCidrException $e) {
+            return false;
+        }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function isPrivateUse()
+    public function isPrivateUse(): bool
     {
-        return $this->inRange(new self(Binary::fromHex('fd000000000000000000000000000000')), 8);
+        try {
+            return $this->inRange(new self(Binary::fromHex('fd000000000000000000000000000000')), 8);
+        } catch (Exception\InvalidCidrException $e) {
+            return false;
+        }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function isUnspecified()
+    public function isUnspecified(): bool
     {
         return $this->getBinary() === "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
     }

--- a/src/Version/MultiVersionInterface.php
+++ b/src/Version/MultiVersionInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Version;
 
@@ -9,21 +9,14 @@ interface MultiVersionInterface extends Version4Interface, Version6Interface
     /**
      * Set the default embedding strategy to be used for all new instances of
      * this class that do not specify their own embedding strategy.
-     *
-     * @static
-     * @param \Darsyn\IP\Strategy\EmbeddingStrategyInterface $strategy
      */
-    public static function setDefaultEmbeddingStrategy(EmbeddingStrategyInterface $strategy);
+    public static function setDefaultEmbeddingStrategy(EmbeddingStrategyInterface $strategy): void;
 
     /**
-     * Get Protocol-appropriate Address
-     *
      * Converts an IP address into the smallest protocol notation it can;
      * dot-notation for IPv4, and compacted (double colons) notation for IPv6.
      * Only IPv4 addresses according to the embedding strategy used will be
      * returned in dot-notation.
-     *
-     * @return string
      */
-    public function getProtocolAppropriateAddress();
+    public function getProtocolAppropriateAddress(): string;
 }

--- a/src/Version/Version4Interface.php
+++ b/src/Version/Version4Interface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Version;
 
@@ -7,14 +7,11 @@ use Darsyn\IP\IpInterface;
 interface Version4Interface extends IpInterface
 {
     /**
-     * Get Dot Address
-     *
      * Convert an IP into an IPv4 dot-notation address string
      * This method will NOT work with IPv6 addresses.
      *
      * @throws \Darsyn\IP\Exception\IpException
      * @throws \Darsyn\IP\Exception\WrongVersionException
-     * @return string
      */
-    public function getDotAddress();
+    public function getDotAddress(): string;
 }

--- a/src/Version/Version6Interface.php
+++ b/src/Version/Version6Interface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Version;
 
@@ -7,24 +7,18 @@ use Darsyn\IP\IpInterface;
 interface Version6Interface extends IpInterface
 {
     /**
-     * Get Compacted Address
-     *
      * Converts an IP (regardless of version) into a compacted IPv6 address
      * (including double-colons if appropriate).
      *
      * @throws \Darsyn\IP\Exception\IpException
-     * @return string
      */
-    public function getCompactedAddress();
+    public function getCompactedAddress(): string;
 
     /**
-     * Get Expanded Address
-     *
      * Converts an IP (regardless of version) address into a full IPv6 address
      * (no double colons).
      *
      * @throws \Darsyn\IP\Exception\IpException
-     * @return string
      */
-    public function getExpandedAddress();
+    public function getExpandedAddress(): string;
 }

--- a/tests/DataProvider/Formatter/ConsistentFormatter.php
+++ b/tests/DataProvider/Formatter/ConsistentFormatter.php
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\DataProvider\Formatter;
 
 class ConsistentFormatter
 {
-    public static function getValidBinarySequences()
+    public static function getValidBinarySequences(): array
     {
         return [
             [pack('H*', '00000000'),                         '0.0.0.0'                         ],
@@ -33,7 +33,7 @@ class ConsistentFormatter
         ];
     }
 
-    public static function getInvalidBinarySequences()
+    public static function getInvalidBinarySequences(): array
     {
         return [
             ['123'],
@@ -41,13 +41,6 @@ class ConsistentFormatter
             ['123456789012345'],
             ['12345678901234567'],
             ['This one is completely wrong.'],
-            // 5 bytes instead of 4.
-            [123],
-            [1.3],
-            [array()],
-            [(object) array()],
-            [null],
-            [true],
         ];
     }
 }

--- a/tests/DataProvider/Formatter/NativeFormatter.php
+++ b/tests/DataProvider/Formatter/NativeFormatter.php
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\DataProvider\Formatter;
 
 class NativeFormatter
 {
-    public static function getValidBinarySequences()
+    public static function getValidBinarySequences(): array
     {
         return [
             [pack('H*', '00000000'), '0.0.0.0'                                            ],
@@ -32,7 +32,7 @@ class NativeFormatter
         ];
     }
 
-    public static function getInvalidBinarySequences()
+    public static function getInvalidBinarySequences(): array
     {
         return [
             ['123'],
@@ -40,13 +40,6 @@ class NativeFormatter
             ['123456789012345'],
             ['12345678901234567'],
             ['This one is completely wrong.'],
-            // 5 bytes instead of 4.
-            [123],
-            [1.3],
-            [array()],
-            [(object) array()],
-            [null],
-            [true],
         ];
     }
 }

--- a/tests/DataProvider/IPv4.php
+++ b/tests/DataProvider/IPv4.php
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\DataProvider;
 
 class IPv4
 {
-    public static function getValidBinarySequences()
+    public static function getValidBinarySequences(): array
     {
         return [
             [pack('H*', '71637a89'), '71637a89', '113.99.122.137' ],
@@ -23,7 +23,7 @@ class IPv4
         ];
     }
 
-    public static function getValidProtocolIpAddresses()
+    public static function getValidProtocolIpAddresses(): array
     {
         return [
             ['119.14.113.44',   '770e712c', '119.14.113.44',   ],
@@ -41,12 +41,12 @@ class IPv4
         ];
     }
 
-    public static function getValidIpAddresses()
+    public static function getValidIpAddresses(): array
     {
         return array_merge(self::getValidBinarySequences(), self::getValidProtocolIpAddresses());
     }
 
-    public static function getInvalidIpAddresses()
+    public static function getInvalidIpAddresses(): array
     {
         return [
             ['::1'],
@@ -56,18 +56,12 @@ class IPv4
             ['This one is completely wrong.'],
             // 5 bytes instead of 4.
             [pack('H*', '20010db80')],
-            [123],
-            [1.3],
-            [array()],
-            [(object) array()],
-            [null],
-            [true],
             ['12345'],
             ['123'],
         ];
     }
 
-    public static function getValidCidrValues()
+    public static function getValidCidrValues(): array
     {
         return [
             [32, 'ffffffff'],
@@ -82,22 +76,15 @@ class IPv4
         ];
     }
 
-    public static function getInvalidCidrValues()
+    public static function getInvalidCidrValues(): array
     {
         return [
             [-1],
             [33],
-            ['0'],
-            ['128'],
-            [12.3],
-            [true],
-            [null],
-            [[]],
-            [(object) []],
         ];
     }
 
-    public static function getNetworkIpAddresses()
+    public static function getNetworkIpAddresses(): array
     {
         return [
             ['12.34.56.78', 32],
@@ -109,7 +96,7 @@ class IPv4
         ];
     }
 
-    public static function getBroadcastIpAddresses()
+    public static function getBroadcastIpAddresses(): array
     {
         return [
             ['12.34.56.78',     32],
@@ -121,7 +108,7 @@ class IPv4
         ];
     }
 
-    public static function getValidInRangeIpAddresses()
+    public static function getValidInRangeIpAddresses(): array
     {
         return [
             ['12.34.56.78',     '12.34.56.78',      32],
@@ -131,7 +118,7 @@ class IPv4
         ];
     }
 
-    public static function getLinkLocalIpAddresses()
+    public static function getLinkLocalIpAddresses(): array
     {
         return [
             ['169.253.255.255', false],
@@ -141,7 +128,7 @@ class IPv4
         ];
     }
 
-    public static function getLoopbackIpAddresses()
+    public static function getLoopbackIpAddresses(): array
     {
         return [
             ['126.255.255.255', false],
@@ -151,7 +138,7 @@ class IPv4
         ];
     }
 
-    public static function getMulticastIpAddresses()
+    public static function getMulticastIpAddresses(): array
     {
         return [
             ['223.255.255.255', false],
@@ -161,7 +148,7 @@ class IPv4
         ];
     }
 
-    public static function getPrivateUseIpAddresses()
+    public static function getPrivateUseIpAddresses(): array
     {
         return [
             ['9.255.255.255',   false],
@@ -179,7 +166,7 @@ class IPv4
         ];
     }
 
-    public static function getUnspecifiedIpAddresses()
+    public static function getUnspecifiedIpAddresses(): array
     {
         return [
             ['0.0.0.0',   true ],

--- a/tests/DataProvider/IPv6.php
+++ b/tests/DataProvider/IPv6.php
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\DataProvider;
 
 class IPv6
 {
-    public static function getValidBinarySequences()
+    public static function getValidBinarySequences(): array
     {
         return [
             // [ constructor value, expected hex, expected expanded address, expected compacted address ].
@@ -23,7 +23,7 @@ class IPv6
         ];
     }
 
-    public static function getValidProtocolIpAddresses()
+    public static function getValidProtocolIpAddresses(): array
     {
         return [
             ['::b12:cab',                       '0000000000000000000000000b120cab', '0000:0000:0000:0000:0000:0000:0b12:0cab', '::b12:cab'                  ],
@@ -40,12 +40,12 @@ class IPv6
         ];
     }
 
-    public static function getValidIpAddresses()
+    public static function getValidIpAddresses(): array
     {
         return array_merge(self::getValidBinarySequences(), self::getValidProtocolIpAddresses());
     }
 
-    public static function getInvalidIpAddresses()
+    public static function getInvalidIpAddresses(): array
     {
         return [
             ['0.0.0.0'],
@@ -56,18 +56,12 @@ class IPv6
             ['This one is completely wrong.'],
             // 15 bytes instead of 16.
             [pack('H*', '20010db8000000000a608a2e037073')],
-            [123],
-            [1.3],
-            [array()],
-            [(object) array()],
-            [null],
-            [true],
             ['12345678901234567'],
             ['123456789012345'],
         ];
     }
 
-    public static function getValidCidrValues()
+    public static function getValidCidrValues(): array
     {
         return [
             [0,   '00000000000000000000000000000000'],
@@ -81,7 +75,7 @@ class IPv6
         ];
     }
 
-    public static function getInvalidCidrValues()
+    public static function getInvalidCidrValues(): array
     {
         return [
             [-1],
@@ -96,7 +90,7 @@ class IPv6
         ];
     }
 
-    public static function getNetworkIpAddresses()
+    public static function getNetworkIpAddresses(): array
     {
         return [
             ['2000::',                      12 ],
@@ -107,7 +101,7 @@ class IPv6
         ];
     }
 
-    public static function getBroadcastIpAddresses()
+    public static function getBroadcastIpAddresses(): array
     {
         return [
             ['200f:ffff:ffff:ffff:ffff:ffff:ffff:ffff', 12 ],
@@ -118,7 +112,7 @@ class IPv6
         ];
     }
 
-    public static function getValidInRangeIpAddresses()
+    public static function getValidInRangeIpAddresses(): array
     {
         return [
             ['d6be:0583:71a4:aa6d:c77d:77dd:0cec:f897', 'd6be:0583:71a4:aa6d:9d68:68f3:dc4a:ce01', 64 ],
@@ -130,7 +124,7 @@ class IPv6
         ];
     }
 
-    public static function getMappedIpAddresses()
+    public static function getMappedIpAddresses(): array
     {
         return [
             ['::ffff:1:0',                              true ],
@@ -145,7 +139,7 @@ class IPv6
         ];
     }
 
-    public static function getDerivedIpAddresses()
+    public static function getDerivedIpAddresses(): array
     {
         return [
             ['2002::',                          true ],
@@ -157,7 +151,7 @@ class IPv6
         ];
     }
 
-    public static function getCompatibleIpAddresses()
+    public static function getCompatibleIpAddresses(): array
     {
         return  [
             ['::7f00:1',                                true ],
@@ -170,7 +164,7 @@ class IPv6
         ];
     }
 
-    public static function getLinkLocalIpAddresses()
+    public static function getLinkLocalIpAddresses(): array
     {
         return [
             ['fe7f:ffff:ffff:ffff:ffff:ffff:ffff:ffff', false],
@@ -180,7 +174,7 @@ class IPv6
         ];
     }
 
-    public static function getLoopbackIpAddresses()
+    public static function getLoopbackIpAddresses(): array
     {
         return [
             ['::1', true ],
@@ -189,7 +183,7 @@ class IPv6
         ];
     }
 
-    public static function getMulticastIpAddresses()
+    public static function getMulticastIpAddresses(): array
     {
         return [
             ['feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', false],
@@ -198,7 +192,7 @@ class IPv6
         ];
     }
 
-    public static function getPrivateUseIpAddresses()
+    public static function getPrivateUseIpAddresses(): array
     {
         return [
             ['fcff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', false],
@@ -208,7 +202,7 @@ class IPv6
         ];
     }
 
-    public static function getUnspecifiedIpAddresses()
+    public static function getUnspecifiedIpAddresses(): array
     {
         return [
             ['::0',             true ],

--- a/tests/DataProvider/Multi.php
+++ b/tests/DataProvider/Multi.php
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\DataProvider;
 
 class Multi
 {
-    public static function getValidBinarySequences()
+    public static function getValidBinarySequences(): array
     {
         return [
             // [ constructor value, expected hex, expected expanded address, expected compacted address, dot notation ].
@@ -28,7 +28,7 @@ class Multi
         ];
     }
 
-    public static function getValidProtocolIpAddresses()
+    public static function getValidProtocolIpAddresses(): array
     {
         return [
             // [ constructor value, expected hex, expected expanded address, expected compacted address, dot notation ].
@@ -51,26 +51,26 @@ class Multi
         ];
     }
 
-    public static function getValidIpAddresses()
+    public static function getValidIpAddresses(): array
     {
         return array_merge(self::getValidBinarySequences(), self::getValidProtocolIpAddresses());
     }
 
-    public static function getValidIpVersion4Addresses()
+    public static function getValidIpVersion4Addresses(): array
     {
         return array_filter(self::getValidIpAddresses(), function (array $row) {
             return is_string($row[4]);
         });
     }
 
-    public static function getValidIpVersion6Addresses()
+    public static function getValidIpVersion6Addresses(): array
     {
         return array_filter(self::getValidIpAddresses(), function (array $row) {
             return !is_string($row[4]);
         });
     }
 
-    public static function getInvalidIpAddresses()
+    public static function getInvalidIpAddresses(): array
     {
         return [
             ['2001:db8::a60:8a2e:370g:7334'],
@@ -79,28 +79,22 @@ class Multi
             ['This one is completely wrong.'],
             // 15 bytes instead of 16.
             [pack('H*', '20010db8000000000a608a2e037073')],
-            [123],
-            [1.3],
-            [array()],
-            [(object) array()],
-            [null],
-            [true],
             ['12345678901234567'],
             ['123456789012345'],
         ];
     }
 
-    public static function getValidCidrValues()
+    public static function getValidCidrValues(): array
     {
         return IPv6::getValidCidrValues();
     }
 
-    public static function getInvalidCidrValues()
+    public static function getInvalidCidrValues(): array
     {
         return IPv6::getInvalidCidrValues();
     }
 
-    public static function getNetworkIpAddresses()
+    public static function getNetworkIpAddresses(): array
     {
         return array_merge(
             array_map(function ($row) {
@@ -115,7 +109,7 @@ class Multi
         );
     }
 
-    public static function getBroadcastIpAddresses()
+    public static function getBroadcastIpAddresses(): array
     {
         return array_merge(
             array_map(function ($row) {
@@ -129,7 +123,7 @@ class Multi
         );
     }
 
-    public static function getValidInRangeIpAddresses()
+    public static function getValidInRangeIpAddresses(): array
     {
         return array_merge(
             array_map(function ($row) {
@@ -147,42 +141,42 @@ class Multi
         );
     }
 
-    public function getMappedIpAddresses()
+    public function getMappedIpAddresses(): array
     {
         return IPv6::getMappedIpAddresses();
     }
 
-    public function getDerivedIpAddresses()
+    public function getDerivedIpAddresses(): array
     {
         return IPv6::getDerivedIpAddresses();
     }
 
-    public function getCompatibleIpAddresses()
+    public function getCompatibleIpAddresses(): array
     {
         return  IPv6::getCompatibleIpAddresses();
     }
 
-    public static function getLinkLocalIpAddresses()
+    public static function getLinkLocalIpAddresses(): array
     {
         return array_merge(IPv4::getLinkLocalIpAddresses(), IPv6::getLinkLocalIpAddresses());
     }
 
-    public static function getLoopbackIpAddresses()
+    public static function getLoopbackIpAddresses(): array
     {
         return array_merge(IPv4::getLoopbackIpAddresses(), IPv6::getLoopbackIpAddresses());
     }
 
-    public static function getMulticastIpAddresses()
+    public static function getMulticastIpAddresses(): array
     {
         return array_merge(IPv4::getMulticastIpAddresses(), IPv6::getMulticastIpAddresses());
     }
 
-    public static function getPrivateUseIpAddresses()
+    public static function getPrivateUseIpAddresses(): array
     {
         return array_merge(IPv4::getPrivateUseIpAddresses(), IPv6::getPrivateUseIpAddresses());
     }
 
-    public static function getUnspecifiedIpAddresses()
+    public static function getUnspecifiedIpAddresses(): array
     {
         return array_merge(IPv4::getUnspecifiedIpAddresses(), IPv6::getUnspecifiedIpAddresses());
     }

--- a/tests/DataProvider/Strategy/Compatible.php
+++ b/tests/DataProvider/Strategy/Compatible.php
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\DataProvider\Strategy;
 
 class Compatible
 {
-    public static function getValidIpAddresses()
+    public static function getValidIpAddresses(): array
     {
         $valid = array_map(function (array $row) {
             $row[1] = true;
@@ -17,18 +17,17 @@ class Compatible
         return array_merge($valid, $invalid);
     }
 
-    public static function getInvalidIpAddresses()
+    public static function getInvalidIpAddresses(): array
     {
         return [
             [pack('H*', '20010db8000000000a608a2e037073')],
             [pack('H*', '20010db8000000000a608a2e0370734556')],
-            [123],
             ['12345678901234567'],
             ['123456789012345'],
         ];
     }
 
-    public static function getValidSequences()
+    public static function getValidSequences(): array
     {
         return [
             [pack('H*', '00000000000000000000000000010000'), pack('H*', '00010000')],
@@ -38,7 +37,7 @@ class Compatible
         ];
     }
 
-    public static function getInvalidSequences()
+    public static function getInvalidSequences(): array
     {
         return [
             [pack('H*', '000000000000000000000fff00010000')],

--- a/tests/DataProvider/Strategy/Derived.php
+++ b/tests/DataProvider/Strategy/Derived.php
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\DataProvider\Strategy;
 
 class Derived
 {
-    public static function getValidIpAddresses()
+    public static function getValidIpAddresses(): array
     {
         $valid = array_map(function (array $row) {
             $row[1] = true;
@@ -17,18 +17,17 @@ class Derived
         return array_merge($valid, $invalid);
     }
 
-    public static function getInvalidIpAddresses()
+    public static function getInvalidIpAddresses(): array
     {
         return [
             [pack('H*', '20010db8000000000a608a2e037073')],
             [pack('H*', '20010db8000000000a608a2e0370734556')],
-            [123],
             ['12345678901234567'],
             ['123456789012345'],
         ];
     }
 
-    public static function getValidSequences()
+    public static function getValidSequences(): array
     {
         return [
             [pack('H*', '20020001000000000000000000000000'), pack('H*', '00010000')],
@@ -38,7 +37,7 @@ class Derived
         ];
     }
 
-    public static function getInvalidSequences()
+    public static function getInvalidSequences(): array
     {
         return [
             [pack('H*', '000000000000000000000fff00010000')],

--- a/tests/DataProvider/Strategy/Mapped.php
+++ b/tests/DataProvider/Strategy/Mapped.php
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\DataProvider\Strategy;
 
 class Mapped
 {
-    public static function getValidIpAddresses()
+    public static function getValidIpAddresses(): array
     {
         $valid = array_map(function (array $row) {
             $row[1] = true;
@@ -17,18 +17,17 @@ class Mapped
         return array_merge($valid, $invalid);
     }
 
-    public static function getInvalidIpAddresses()
+    public static function getInvalidIpAddresses(): array
     {
         return [
             [pack('H*', '20010db8000000000a608a2e037073')],
             [pack('H*', '20010db8000000000a608a2e0370734556')],
-            [123],
             ['12345678901234567'],
             ['123456789012345'],
         ];
     }
 
-    public static function getValidSequences()
+    public static function getValidSequences(): array
     {
         return [
             [pack('H*', '00000000000000000000ffff00010000'), pack('H*', '00010000')],
@@ -38,7 +37,7 @@ class Mapped
         ];
     }
 
-    public static function getInvalidSequences()
+    public static function getInvalidSequences(): array
     {
         return [
             [pack('H*', '000000000000000000000fff00010000')],

--- a/tests/Doctrine/IPv4TypeTest.php
+++ b/tests/Doctrine/IPv4TypeTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\Doctrine;
 
@@ -16,14 +16,14 @@ class IPv4TypeTest extends TestCase
     /** @var \Darsyn\IP\Doctrine\IPv4Type $type */
     private $type;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (class_exists(Type::class)) {
             Type::addType('ipv4', IPv4Type::class);
         }
     }
 
-    private function getPlatformMock()
+    private function getPlatformMock(): \PHPUnit_Framework_MockObject_MockObject
     {
         // We have to use MySQL as the platform here, because the AbstractPlatform does not support BINARY types.
         return $this
@@ -32,7 +32,7 @@ class IPv4TypeTest extends TestCase
             ->getMockForAbstractClass();
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!class_exists('Doctrine\DBAL\Types\Type')) {
@@ -50,7 +50,7 @@ class IPv4TypeTest extends TestCase
     /**
      * @test
      */
-    public function testIpConvertsToDatabaseValue()
+    public function testIpConvertsToDatabaseValue(): void
     {
         $ip = IP::factory('12.34.56.78');
 
@@ -64,7 +64,7 @@ class IPv4TypeTest extends TestCase
      * @test
      * @expectedException \Doctrine\DBAL\Types\ConversionException
      */
-    public function testInvalidIpConversionForDatabaseValue()
+    public function testInvalidIpConversionForDatabaseValue(): void
     {
         $this->type->convertToDatabaseValue('abcdefg', $this->platform);
     }
@@ -72,7 +72,7 @@ class IPv4TypeTest extends TestCase
     /**
      * @test
      */
-    public function testNullConversionForDatabaseValue()
+    public function testNullConversionForDatabaseValue(): void
     {
         $this->assertNull($this->type->convertToDatabaseValue(null, $this->platform));
     }
@@ -80,7 +80,7 @@ class IPv4TypeTest extends TestCase
     /**
      * @test
      */
-    public function testIpConvertsToPHPValue()
+    public function testIpConvertsToPHPValue(): void
     {
         $ip = IP::factory('12.34.56.78');
         /** @var IP $dbIp */
@@ -92,7 +92,7 @@ class IPv4TypeTest extends TestCase
     /**
      * @test
      */
-    public function testIpObjectConvertsToPHPValue()
+    public function testIpObjectConvertsToPHPValue(): void
     {
         $ip = IP::factory('12.34.56.78');
         /** @var IP $dbIp */
@@ -104,7 +104,7 @@ class IPv4TypeTest extends TestCase
     /**
      * @test
      */
-    public function testStreamConvertsToPHPValue()
+    public function testStreamConvertsToPHPValue(): void
     {
         $ip = IP::factory('12.34.56.78');
         $stream = fopen('php://memory','r+');
@@ -120,7 +120,7 @@ class IPv4TypeTest extends TestCase
      * @test
      * @expectedException \Doctrine\DBAL\Types\ConversionException
      */
-    public function testInvalidIpConversionForPHPValue()
+    public function testInvalidIpConversionForPHPValue(): void
     {
         $this->type->convertToPHPValue('abcdefg', $this->platform);
     }
@@ -128,7 +128,7 @@ class IPv4TypeTest extends TestCase
     /**
      * @test
      */
-    public function testNullConversionForPHPValue()
+    public function testNullConversionForPHPValue(): void
     {
         $this->assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
@@ -136,7 +136,7 @@ class IPv4TypeTest extends TestCase
     /**
      * @test
      */
-    public function testGetName()
+    public function testGetName(): void
     {
         $this->assertEquals('ip', $this->type->getName());
     }
@@ -144,7 +144,7 @@ class IPv4TypeTest extends TestCase
     /**
      * @test
      */
-    public function testGetBinaryTypeDeclarationSQL()
+    public function testGetBinaryTypeDeclarationSQL(): void
     {
         $this->assertEquals('DUMMYBINARY()', $this->type->getSqlDeclaration(['length' => 4], $this->platform));
     }
@@ -152,7 +152,7 @@ class IPv4TypeTest extends TestCase
     /**
      * @test
      */
-    public function testBindingTypeIsAValidPDOTypeConstant()
+    public function testBindingTypeIsAValidPDOTypeConstant(): void
     {
         // Get all constants of the PDO class.
         $constants = (new \ReflectionClass(PDO::class))->getConstants();
@@ -171,7 +171,7 @@ class IPv4TypeTest extends TestCase
     /**
      * @test
      */
-    public function testRequiresSQLCommentHint()
+    public function testRequiresSQLCommentHint(): void
     {
         $this->assertTrue($this->type->requiresSQLCommentHint($this->platform));
     }

--- a/tests/Doctrine/IPv6TypeTest.php
+++ b/tests/Doctrine/IPv6TypeTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\Doctrine;
 
@@ -16,14 +16,14 @@ class IPv6TypeTest extends TestCase
     /** @var \Darsyn\IP\Doctrine\IPv6Type $type */
     private $type;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (class_exists(Type::class)) {
             Type::addType('ipv6', IPv6Type::class);
         }
     }
 
-    private function getPlatformMock()
+    private function getPlatformMock(): \PHPUnit_Framework_MockObject_MockObject
     {
         // We have to use MySQL as the platform here, because the AbstractPlatform does not support BINARY types.
         return $this
@@ -32,7 +32,7 @@ class IPv6TypeTest extends TestCase
             ->getMockForAbstractClass();
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!class_exists('Doctrine\DBAL\Types\Type')) {
@@ -50,7 +50,7 @@ class IPv6TypeTest extends TestCase
     /**
      * @test
      */
-    public function testIpConvertsToDatabaseValue()
+    public function testIpConvertsToDatabaseValue(): void
     {
         $ip = IP::factory('::1');
 
@@ -64,7 +64,7 @@ class IPv6TypeTest extends TestCase
      * @test
      * @expectedException \Doctrine\DBAL\Types\ConversionException
      */
-    public function testInvalidIpConversionForDatabaseValue()
+    public function testInvalidIpConversionForDatabaseValue(): void
     {
         $this->type->convertToDatabaseValue('abcdefg', $this->platform);
     }
@@ -72,7 +72,7 @@ class IPv6TypeTest extends TestCase
     /**
      * @test
      */
-    public function testNullConversionForDatabaseValue()
+    public function testNullConversionForDatabaseValue(): void
     {
         $this->assertNull($this->type->convertToDatabaseValue(null, $this->platform));
     }
@@ -80,7 +80,7 @@ class IPv6TypeTest extends TestCase
     /**
      * @test
      */
-    public function testIpConvertsToPHPValue()
+    public function testIpConvertsToPHPValue(): void
     {
         $ip = IP::factory('::1');
         /** @var IP $dbIp */
@@ -92,7 +92,7 @@ class IPv6TypeTest extends TestCase
     /**
      * @test
      */
-    public function testIpObjectConvertsToPHPValue()
+    public function testIpObjectConvertsToPHPValue(): void
     {
         $ip = IP::factory('::1');
         /** @var IP $dbIp */
@@ -104,7 +104,7 @@ class IPv6TypeTest extends TestCase
     /**
      * @test
      */
-    public function testStreamConvertsToPHPValue()
+    public function testStreamConvertsToPHPValue(): void
     {
         $ip = IP::factory('::1');
         $stream = fopen('php://memory','r+');
@@ -120,7 +120,7 @@ class IPv6TypeTest extends TestCase
      * @test
      * @expectedException \Doctrine\DBAL\Types\ConversionException
      */
-    public function testInvalidIpConversionForPHPValue()
+    public function testInvalidIpConversionForPHPValue(): void
     {
         $this->type->convertToPHPValue('abcdefg', $this->platform);
     }
@@ -128,7 +128,7 @@ class IPv6TypeTest extends TestCase
     /**
      * @test
      */
-    public function testNullConversionForPHPValue()
+    public function testNullConversionForPHPValue(): void
     {
         $this->assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
@@ -136,7 +136,7 @@ class IPv6TypeTest extends TestCase
     /**
      * @test
      */
-    public function testGetName()
+    public function testGetName(): void
     {
         $this->assertEquals('ip', $this->type->getName());
     }
@@ -144,7 +144,7 @@ class IPv6TypeTest extends TestCase
     /**
      * @test
      */
-    public function testGetBinaryTypeDeclarationSQL()
+    public function testGetBinaryTypeDeclarationSQL(): void
     {
         $this->assertEquals('DUMMYBINARY()', $this->type->getSqlDeclaration(['length' => 16], $this->platform));
     }
@@ -152,7 +152,7 @@ class IPv6TypeTest extends TestCase
     /**
      * @test
      */
-    public function testBindingTypeIsAValidPDOTypeConstant()
+    public function testBindingTypeIsAValidPDOTypeConstant(): void
     {
         // Get all constants of the PDO class.
         $constants = (new \ReflectionClass(PDO::class))->getConstants();
@@ -171,7 +171,7 @@ class IPv6TypeTest extends TestCase
     /**
      * @test
      */
-    public function testRequiresSQLCommentHint()
+    public function testRequiresSQLCommentHint(): void
     {
         $this->assertTrue($this->type->requiresSQLCommentHint($this->platform));
     }

--- a/tests/Doctrine/MultiTypeTest.php
+++ b/tests/Doctrine/MultiTypeTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\Doctrine;
 
@@ -16,14 +16,14 @@ class MultiTypeTest extends TestCase
     /** @var \Darsyn\IP\Doctrine\MultiType $type */
     private $type;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (class_exists(Type::class)) {
             Type::addType('ip_multi', MultiType::class);
         }
     }
 
-    private function getPlatformMock()
+    private function getPlatformMock(): \PHPUnit_Framework_MockObject_MockObject
     {
         // We have to use MySQL as the platform here, because the AbstractPlatform does not support BINARY types.
         return $this
@@ -32,7 +32,7 @@ class MultiTypeTest extends TestCase
             ->getMockForAbstractClass();
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!class_exists('Doctrine\DBAL\Types\Type')) {
@@ -50,7 +50,7 @@ class MultiTypeTest extends TestCase
     /**
      * @test
      */
-    public function testIpConvertsToDatabaseValue()
+    public function testIpConvertsToDatabaseValue(): void
     {
         $ip = IP::factory('12.34.56.78');
 
@@ -64,7 +64,7 @@ class MultiTypeTest extends TestCase
      * @test
      * @expectedException \Doctrine\DBAL\Types\ConversionException
      */
-    public function testInvalidIpConversionForDatabaseValue()
+    public function testInvalidIpConversionForDatabaseValue(): void
     {
         $this->type->convertToDatabaseValue('abcdefg', $this->platform);
     }
@@ -72,7 +72,7 @@ class MultiTypeTest extends TestCase
     /**
      * @test
      */
-    public function testNullConversionForDatabaseValue()
+    public function testNullConversionForDatabaseValue(): void
     {
         $this->assertNull($this->type->convertToDatabaseValue(null, $this->platform));
     }
@@ -80,7 +80,7 @@ class MultiTypeTest extends TestCase
     /**
      * @test
      */
-    public function testIpConvertsToPHPValue()
+    public function testIpConvertsToPHPValue(): void
     {
         $ip = IP::factory('12.34.56.78');
         /** @var IP $dbIp */
@@ -92,7 +92,7 @@ class MultiTypeTest extends TestCase
     /**
      * @test
      */
-    public function testIpObjectConvertsToPHPValue()
+    public function testIpObjectConvertsToPHPValue(): void
     {
         $ip = IP::factory('12.34.56.78');
         /** @var IP $dbIp */
@@ -104,7 +104,7 @@ class MultiTypeTest extends TestCase
     /**
      * @test
      */
-    public function testStreamConvertsToPHPValue()
+    public function testStreamConvertsToPHPValue(): void
     {
         $ip = IP::factory('12.34.56.78');
         $stream = fopen('php://memory','r+');
@@ -120,7 +120,7 @@ class MultiTypeTest extends TestCase
      * @test
      * @expectedException \Doctrine\DBAL\Types\ConversionException
      */
-    public function testInvalidIpConversionForPHPValue()
+    public function testInvalidIpConversionForPHPValue(): void
     {
         $this->type->convertToPHPValue('abcdefg', $this->platform);
     }
@@ -128,7 +128,7 @@ class MultiTypeTest extends TestCase
     /**
      * @test
      */
-    public function testNullConversionForPHPValue()
+    public function testNullConversionForPHPValue(): void
     {
         $this->assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
@@ -136,7 +136,7 @@ class MultiTypeTest extends TestCase
     /**
      * @test
      */
-    public function testGetName()
+    public function testGetName(): void
     {
         $this->assertEquals('ip', $this->type->getName());
     }
@@ -144,7 +144,7 @@ class MultiTypeTest extends TestCase
     /**
      * @test
      */
-    public function testGetBinaryTypeDeclarationSQL()
+    public function testGetBinaryTypeDeclarationSQL(): void
     {
         $this->assertEquals('DUMMYBINARY()', $this->type->getSqlDeclaration(['length' => 16], $this->platform));
     }
@@ -152,7 +152,7 @@ class MultiTypeTest extends TestCase
     /**
      * @test
      */
-    public function testBindingTypeIsAValidPDOTypeConstant()
+    public function testBindingTypeIsAValidPDOTypeConstant(): void
     {
         // Get all constants of the PDO class.
         $constants = (new \ReflectionClass(PDO::class))->getConstants();
@@ -171,7 +171,7 @@ class MultiTypeTest extends TestCase
     /**
      * @test
      */
-    public function testRequiresSQLCommentHint()
+    public function testRequiresSQLCommentHint(): void
     {
         $this->assertTrue($this->type->requiresSQLCommentHint($this->platform));
     }

--- a/tests/Formatter/ConsistentFormatterTest.php
+++ b/tests/Formatter/ConsistentFormatterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\Formatter;
 
@@ -12,7 +12,7 @@ class ConsistentFormatterTest extends TestCase
     /** @var \Darsyn\IP\Formatter\ProtocolFormatterInterface $formatter */
     private $formatter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->formatter = new Formatter;
@@ -21,7 +21,7 @@ class ConsistentFormatterTest extends TestCase
     /**
      * @test
      */
-    public function testFormatterIsInstanceOfInterface()
+    public function testFormatterIsInstanceOfInterface(): void
     {
         $this->assertInstanceOf(ProtocolFormatterInterface::class, $this->formatter);
     }
@@ -30,7 +30,7 @@ class ConsistentFormatterTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Formatter\ConsistentFormatter::getValidBinarySequences()
      */
-    public function testFormatterReturnsCorrectProtocolString($value, $expected)
+    public function testFormatterReturnsCorrectProtocolString($value, $expected): void
     {
         $this->assertSame($expected, $this->formatter->ntop($value));
     }
@@ -40,7 +40,7 @@ class ConsistentFormatterTest extends TestCase
      * @expectedException \Darsyn\IP\Exception\Formatter\FormatException
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Formatter\ConsistentFormatter::getInvalidBinarySequences()
      */
-    public function testFormatterThrowsExceptionOnInvalidBinarySequences($value)
+    public function testFormatterThrowsExceptionOnInvalidBinarySequences($value): void
     {
         try {
             $this->formatter->ntop($value);

--- a/tests/Formatter/NativeFormatterTest.php
+++ b/tests/Formatter/NativeFormatterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\Formatter;
 
@@ -12,7 +12,7 @@ class NativeFormatterTest extends TestCase
     /** @var \Darsyn\IP\Formatter\ProtocolFormatterInterface $formatter */
     private $formatter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->formatter = new Formatter;
@@ -21,7 +21,7 @@ class NativeFormatterTest extends TestCase
     /**
      * @test
      */
-    public function testFormatterIsInstanceOfInterface()
+    public function testFormatterIsInstanceOfInterface(): void
     {
         $this->assertInstanceOf(ProtocolFormatterInterface::class, $this->formatter);
     }
@@ -30,7 +30,7 @@ class NativeFormatterTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Formatter\NativeFormatter::getValidBinarySequences()
      */
-    public function testFormatterReturnsCorrectProtocolString($value, $expected)
+    public function testFormatterReturnsCorrectProtocolString($value, $expected): void
     {
         $this->assertSame($expected, $this->formatter->ntop($value));
     }
@@ -40,7 +40,7 @@ class NativeFormatterTest extends TestCase
      * @expectedException \Darsyn\IP\Exception\Formatter\FormatException
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Formatter\NativeFormatter::getInvalidBinarySequences()
      */
-    public function testFormatterThrowsExceptionOnInvalidBinarySequences($value)
+    public function testFormatterThrowsExceptionOnInvalidBinarySequences($value): void
     {
         try {
             $this->formatter->ntop($value);

--- a/tests/Strategy/CompatibleTest.php
+++ b/tests/Strategy/CompatibleTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\Strategy;
 
@@ -12,7 +12,7 @@ class CompatibleTest extends TestCase
     /** @var \Darsyn\IP\Strategy\EmbeddingStrategyInterface $strategy */
     private $strategy;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->strategy = new Compatible;
@@ -22,7 +22,7 @@ class CompatibleTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Compatible::getInvalidIpAddresses()
      */
-    public function testIsEmbeddedReturnsFalseForAStringOtherThan16BytesLong($value)
+    public function testIsEmbeddedReturnsFalseForAStringOtherThan16BytesLong($value): void
     {
         $this->assertFalse($this->strategy->isEmbedded($value));
     }
@@ -31,7 +31,7 @@ class CompatibleTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Compatible::getValidIpAddresses()
      */
-    public function testIsEmbedded($value, $isEmbedded)
+    public function testIsEmbedded($value, $isEmbedded): void
     {
         $this->assertSame($isEmbedded, $this->strategy->isEmbedded($value));
     }
@@ -41,7 +41,7 @@ class CompatibleTest extends TestCase
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Compatible::getInvalidIpAddresses()
      * @expectedException \Darsyn\IP\Exception\Strategy\ExtractionException
      */
-    public function testExceptionIsThrownWhenTryingToExtractFromStringsNot16Bytes($value)
+    public function testExceptionIsThrownWhenTryingToExtractFromStringsNot16Bytes($value): void
     {
         try {
             $this->strategy->extract($value);
@@ -57,7 +57,7 @@ class CompatibleTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Compatible::getValidSequences()
      */
-    public function testCorrectSequenceExtractedFromIpBinary($ipv6, $ipv4)
+    public function testCorrectSequenceExtractedFromIpBinary($ipv6, $ipv4): void
     {
         $this->assertSame($ipv4, $this->strategy->extract($ipv6));
     }
@@ -67,7 +67,7 @@ class CompatibleTest extends TestCase
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Compatible::getInvalidIpAddresses()
      * @expectedException \Darsyn\IP\Exception\Strategy\PackingException
      */
-    public function testExceptionIsThrownWhenTryingToPackStringsNot4Bytes($value)
+    public function testExceptionIsThrownWhenTryingToPackStringsNot4Bytes($value): void
     {
         try {
             $this->strategy->pack($value);
@@ -83,7 +83,7 @@ class CompatibleTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Compatible::getValidSequences()
      */
-    public function testSequenceCorrectlyPackedIntoIpBinaryFromIpBinary($ipv6, $ipv4)
+    public function testSequenceCorrectlyPackedIntoIpBinaryFromIpBinary($ipv6, $ipv4): void
     {
         $this->assertSame($ipv6, $this->strategy->pack($ipv4));
     }

--- a/tests/Strategy/DerivedTest.php
+++ b/tests/Strategy/DerivedTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\Strategy;
 
@@ -10,7 +10,7 @@ class DerivedTest extends TestCase
     /** @var \Darsyn\IP\Strategy\EmbeddingStrategyInterface $strategy */
     private $strategy;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->strategy = new Derived;
@@ -20,7 +20,7 @@ class DerivedTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Derived::getInvalidIpAddresses()
      */
-    public function testIsEmbeddedReturnsFalseForAStringOtherThan16BytesLong($value)
+    public function testIsEmbeddedReturnsFalseForAStringOtherThan16BytesLong($value): void
     {
         $this->assertFalse($this->strategy->isEmbedded($value));
     }
@@ -29,7 +29,7 @@ class DerivedTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Derived::getValidIpAddresses()
      */
-    public function testIsEmbedded($value, $isEmbedded)
+    public function testIsEmbedded($value, $isEmbedded): void
     {
         $this->assertSame($isEmbedded, $this->strategy->isEmbedded($value));
     }
@@ -39,7 +39,7 @@ class DerivedTest extends TestCase
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Derived::getInvalidIpAddresses()
      * @expectedException \Darsyn\IP\Exception\Strategy\ExtractionException
      */
-    public function testExceptionIsThrownWhenTryingToExtractFromStringsNot16Bytes($value)
+    public function testExceptionIsThrownWhenTryingToExtractFromStringsNot16Bytes($value): void
     {
         $this->strategy->extract($value);
     }
@@ -48,7 +48,7 @@ class DerivedTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Derived::getValidSequences()
      */
-    public function testCorrectSequenceExtractedFromIpBinary($ipv6, $ipv4)
+    public function testCorrectSequenceExtractedFromIpBinary($ipv6, $ipv4): void
     {
         $this->assertSame($ipv4, $this->strategy->extract($ipv6));
     }
@@ -58,7 +58,7 @@ class DerivedTest extends TestCase
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Derived::getInvalidIpAddresses()
      * @expectedException \Darsyn\IP\Exception\Strategy\PackingException
      */
-    public function testExceptionIsThrownWhenTryingToPackStringsNot4Bytes($value)
+    public function testExceptionIsThrownWhenTryingToPackStringsNot4Bytes($value): void
     {
         $this->strategy->pack($value);
     }
@@ -67,7 +67,7 @@ class DerivedTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Derived::getValidSequences()
      */
-    public function testSequenceCorrectlyPackedIntoIpBinaryFromIpBinary($ipv6, $ipv4)
+    public function testSequenceCorrectlyPackedIntoIpBinaryFromIpBinary($ipv6, $ipv4): void
     {
         $this->assertSame($ipv6, $this->strategy->pack($ipv4));
     }

--- a/tests/Strategy/MappedTest.php
+++ b/tests/Strategy/MappedTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\Strategy;
 
@@ -10,7 +10,7 @@ class MappedTest extends TestCase
     /** @var \Darsyn\IP\Strategy\EmbeddingStrategyInterface $strategy */
     private $strategy;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->strategy = new Mapped;
@@ -20,7 +20,7 @@ class MappedTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Mapped::getInvalidIpAddresses()
      */
-    public function testIsEmbeddedReturnsFalseForAStringOtherThan16BytesLong($value)
+    public function testIsEmbeddedReturnsFalseForAStringOtherThan16BytesLong($value): void
     {
         $this->assertFalse($this->strategy->isEmbedded($value));
     }
@@ -29,7 +29,7 @@ class MappedTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Mapped::getValidIpAddresses()
      */
-    public function testIsEmbedded($value, $isEmbedded)
+    public function testIsEmbedded($value, $isEmbedded): void
     {
         $this->assertSame($isEmbedded, $this->strategy->isEmbedded($value));
     }
@@ -39,7 +39,7 @@ class MappedTest extends TestCase
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Mapped::getInvalidIpAddresses()
      * @expectedException \Darsyn\IP\Exception\Strategy\ExtractionException
      */
-    public function testExceptionIsThrownWhenTryingToExtractFromStringsNot16Bytes($value)
+    public function testExceptionIsThrownWhenTryingToExtractFromStringsNot16Bytes($value): void
     {
         $this->strategy->extract($value);
     }
@@ -48,7 +48,7 @@ class MappedTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Mapped::getValidSequences()
      */
-    public function testCorrectSequenceExtractedFromIpBinary($ipv6, $ipv4)
+    public function testCorrectSequenceExtractedFromIpBinary($ipv6, $ipv4): void
     {
         $this->assertSame($ipv4, $this->strategy->extract($ipv6));
     }
@@ -58,7 +58,7 @@ class MappedTest extends TestCase
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Mapped::getInvalidIpAddresses()
      * @expectedException \Darsyn\IP\Exception\Strategy\PackingException
      */
-    public function testExceptionIsThrownWhenTryingToPackStringsNot4Bytes($value)
+    public function testExceptionIsThrownWhenTryingToPackStringsNot4Bytes($value): void
     {
         $this->strategy->pack($value);
     }
@@ -67,7 +67,7 @@ class MappedTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Mapped::getValidSequences()
      */
-    public function testSequenceCorrectlyPackedIntoIpBinaryFromIpBinary($ipv6, $ipv4)
+    public function testSequenceCorrectlyPackedIntoIpBinaryFromIpBinary($ipv6, $ipv4): void
     {
         $this->assertSame($ipv6, $this->strategy->pack($ipv4));
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,12 +1,12 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests;
 
-use PHPUnit_Framework_TestCase as BaseTestCase;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         if (PHP_INT_SIZE == 4) {
             $this->markTestSkipped('Skipping test that can run only on a 64-bit build of PHP.');

--- a/tests/Version/IPv4Test.php
+++ b/tests/Version/IPv4Test.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\Version;
 
@@ -16,7 +16,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      */
-    public function testInstantiationWithValidAddresses($value)
+    public function testInstantiationWithValidAddresses($value): void
     {
         $ip = IP::factory($value);
         $this->assertInstanceOf(IpInterface::class, $ip);
@@ -27,7 +27,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidBinarySequences()
      */
-    public function testBinarySequenceIsTheSameOnceInstantiated($value)
+    public function testBinarySequenceIsTheSameOnceInstantiated($value): void
     {
         $ip = IP::factory($value);
         $this->assertSame($value, $ip->getBinary());
@@ -37,7 +37,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidProtocolIpAddresses()
      */
-    public function testProtocolNotationConvertsToCorrectBinarySequence($value, $expectedHex)
+    public function testProtocolNotationConvertsToCorrectBinarySequence($value, $expectedHex): void
     {
         $ip = IP::factory($value);
         $this->assertSame($expectedHex, unpack('H*hex', $ip->getBinary())['hex']);
@@ -49,7 +49,7 @@ class IPv4Test extends TestCase
      * @expectedException \Darsyn\IP\Exception\InvalidIpAddressException
      * @expectedExceptionMessage The IP address supplied is not valid.
      */
-    public function testExceptionIsThrownOnInstantiationWithInvalidAddresses($value)
+    public function testExceptionIsThrownOnInstantiationWithInvalidAddresses($value): void
     {
         try {
             IP::factory($value);
@@ -64,7 +64,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      */
-    public function testGetBinaryAlwaysReturnsA4ByteString($value)
+    public function testGetBinaryAlwaysReturnsA4ByteString($value): void
     {
         $ip = IP::factory($value);
         $this->assertSame(4, strlen(bin2hex($ip->getBinary())) / 2);
@@ -74,7 +74,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      */
-    public function testDotAddressReturnsCorrectString($value, $expectedHex, $expectedDot)
+    public function testDotAddressReturnsCorrectString($value, $expectedHex, $expectedDot): void
     {
         $ip = IP::factory($value);
         $this->assertSame($expectedDot, $ip->getDotAddress());
@@ -84,7 +84,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      */
-    public function testGetVersionAlwaysReturns4($value)
+    public function testGetVersionAlwaysReturns4($value): void
     {
         $ip = IP::factory($value);
         $this->assertSame(4, $ip->getVersion());
@@ -94,7 +94,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      */
-    public function testIsVersionOnlyReturnsTrueFor4($value)
+    public function testIsVersionOnlyReturnsTrueFor4($value): void
     {
         $ip = IP::factory($value);
         $this->assertTrue($ip->isVersion(4));
@@ -104,7 +104,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      */
-    public function testIsVersionOnlyReturnsFalseFor6($value)
+    public function testIsVersionOnlyReturnsFalseFor6($value): void
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isVersion(6));
@@ -114,7 +114,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      */
-    public function testIsVersion4AlwaysReturnsTrue($value)
+    public function testIsVersion4AlwaysReturnsTrue($value): void
     {
         $ip = IP::factory($value);
         $this->assertTrue($ip->isVersion4());
@@ -124,7 +124,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      */
-    public function testIsVersion6AlwaysReturnsFalse($value)
+    public function testIsVersion6AlwaysReturnsFalse($value): void
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isVersion6());
@@ -134,7 +134,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidCidrValues()
      */
-    public function testCidrMasks($cidr, $expectedMaskHex)
+    public function testCidrMasks($cidr, $expectedMaskHex): void
     {
         $ip = IP::factory('12.34.56.78');
         $reflect = new \ReflectionClass($ip);
@@ -149,7 +149,7 @@ class IPv4Test extends TestCase
      * @expectedException \Darsyn\IP\Exception\InvalidCidrException
      * @expectedExceptionMessage The CIDR supplied is not valid; it must be an integer between 0 and 32.
      */
-    public function testExceptionIsThrownFromInvalidCidrValues($cidr)
+    public function testExceptionIsThrownFromInvalidCidrValues($cidr): void
     {
         $ip = IP::factory('12.34.56.78');
         $reflect = new \ReflectionClass($ip);
@@ -168,7 +168,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Ipv4::getNetworkIpAddresses()
      */
-    public function testNetworkIp($expected, $cidr)
+    public function testNetworkIp($expected, $cidr): void
     {
         $ip = IP::factory('12.34.56.78');
         $this->assertSame($expected, $ip->getNetworkIp($cidr)->getDotAddress());
@@ -178,7 +178,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Ipv4::getBroadcastIpAddresses()
      */
-    public function testBroadcastIp($expected, $cidr)
+    public function testBroadcastIp($expected, $cidr): void
     {
         $ip = IP::factory('12.34.56.78');
         $this->assertSame($expected, $ip->getBroadcastIp($cidr)->getDotAddress());
@@ -188,7 +188,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidInRangeIpAddresses()
      */
-    public function testInRange($first, $second, $cidr)
+    public function testInRange($first, $second, $cidr): void
     {
         $first = IP::factory($first);
         $second = IP::factory($second);
@@ -199,7 +199,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getInvalidCidrValues()
      */
-    public function testInRangeReturnsFalseInsteadOfExceptionOnInvalidCidr($cidr)
+    public function testInRangeReturnsFalseInsteadOfExceptionOnInvalidCidr($cidr): void
     {
         $first = IP::factory('12.34.56.78');
         $second = IP::factory('12.34.56.78');
@@ -209,7 +209,7 @@ class IPv4Test extends TestCase
     /**
      * @test
      */
-    public function testDifferentVersionsAreNotInRange()
+    public function testDifferentVersionsAreNotInRange(): void
     {
         $ip = IP::factory('12.34.56.78');
         $other = IPv6::factory('::12.34.56.78');
@@ -220,7 +220,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      */
-    public function testIsMappedAlwaysReturnsFalse($value)
+    public function testIsMappedAlwaysReturnsFalse($value): void
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isMapped());
@@ -230,7 +230,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      */
-    public function testIsDerivedAlwaysReturnsFalse($value)
+    public function testIsDerivedAlwaysReturnsFalse($value): void
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isDerived());
@@ -240,7 +240,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      */
-    public function testIsCompatibleAlwaysReturnsFalse($value)
+    public function testIsCompatibleAlwaysReturnsFalse($value): void
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isCompatible());
@@ -250,7 +250,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      */
-    public function testIsEmbeddedAlwaysReturnsFalse($value)
+    public function testIsEmbeddedAlwaysReturnsFalse($value): void
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isEmbedded());
@@ -260,7 +260,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getLinkLocalIpAddresses()
      */
-    public function testIsLinkLocal($value, $isLinkLocal)
+    public function testIsLinkLocal($value, $isLinkLocal): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isLinkLocal, $ip->isLinkLocal());
@@ -270,7 +270,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getLoopbackIpAddresses()
      */
-    public function testIsLoopback($value, $isLoopback)
+    public function testIsLoopback($value, $isLoopback): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isLoopback, $ip->isLoopback());
@@ -280,7 +280,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getMulticastIpAddresses()
      */
-    public function testIsMulticast($value, $isMulticast)
+    public function testIsMulticast($value, $isMulticast): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isMulticast, $ip->isMulticast());
@@ -291,7 +291,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getPrivateUseIpAddresses()
      */
-    public function testIsPrivateUse($value, $isPrivateUse)
+    public function testIsPrivateUse($value, $isPrivateUse): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isPrivateUse, $ip->isPrivateUse());
@@ -301,7 +301,7 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getUnspecifiedIpAddresses()
      */
-    public function testIsUnspecified($value, $isUnspecified)
+    public function testIsUnspecified($value, $isUnspecified): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isUnspecified, $ip->isUnspecified());

--- a/tests/Version/IPv6Test.php
+++ b/tests/Version/IPv6Test.php
@@ -1,7 +1,8 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\Version;
 
+use Darsyn\IP\Binary;
 use Darsyn\IP\Exception\InvalidCidrException;
 use Darsyn\IP\Exception\InvalidIpAddressException;
 use Darsyn\IP\IpInterface;
@@ -16,7 +17,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidIpAddresses()
      */
-    public function testInstantiationWithValidAddresses($value)
+    public function testInstantiationWithValidAddresses($value): void
     {
         $ip = IP::factory($value);
         $this->assertInstanceOf(IpInterface::class, $ip);
@@ -27,7 +28,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidBinarySequences()
      */
-    public function testBinarySequenceIsTheSameOnceInstantiated($value)
+    public function testBinarySequenceIsTheSameOnceInstantiated($value): void
     {
         $ip = IP::factory($value);
         $this->assertSame($value, $ip->getBinary());
@@ -37,7 +38,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidProtocolIpAddresses()
      */
-    public function testProtocolNotationConvertsToCorrectBinarySequence($value, $hex)
+    public function testProtocolNotationConvertsToCorrectBinarySequence($value, $hex): void
     {
         $ip = IP::factory($value);
         $this->assertSame($hex, unpack('H*hex', $ip->getBinary())['hex']);
@@ -49,7 +50,7 @@ class IPv6Test extends TestCase
      * @expectedException \Darsyn\IP\Exception\InvalidIpAddressException
      * @expectedExceptionMessage The IP address supplied is not valid.
      */
-    public function testExceptionIsThrownOnInstantiationWithInvalidAddresses($value)
+    public function testExceptionIsThrownOnInstantiationWithInvalidAddresses($value): void
     {
         try {
             $ip = IP::factory($value);
@@ -64,7 +65,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidIpAddresses()
      */
-    public function testGetBinaryAlwaysReturnsA16ByteString($value)
+    public function testGetBinaryAlwaysReturnsA16ByteString($value): void
     {
         $ip = IP::factory($value);
         $this->assertSame(16, strlen(bin2hex($ip->getBinary())) / 2);
@@ -74,7 +75,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidIpAddresses()
      */
-    public function testGetCompactedAddressReturnsCorrectString($value, $hex, $expanded, $compacted)
+    public function testGetCompactedAddressReturnsCorrectString($value, $hex, $expanded, $compacted): void
     {
         $ip = IP::factory($value);
         $this->assertSame($compacted, $ip->getCompactedAddress());
@@ -84,7 +85,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidProtocolIpAddresses()
      */
-    public function testGetExpandedAddressReturnsCorrectString($value, $hex, $expanded)
+    public function testGetExpandedAddressReturnsCorrectString($value, $hex, $expanded): void
     {
         $ip = IP::factory($value);
         $this->assertSame($expanded, $ip->getExpandedAddress());
@@ -94,7 +95,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidIpAddresses()
      */
-    public function testGetVersionAlwaysReturns6($value)
+    public function testGetVersionAlwaysReturns6($value): void
     {
         $ip = IP::factory($value);
         $this->assertSame(6, $ip->getVersion());
@@ -104,7 +105,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidIpAddresses()
      */
-    public function testIsVersionOnlyReturnsTrueFor6($value)
+    public function testIsVersionOnlyReturnsTrueFor6($value): void
     {
         $ip = IP::factory($value);
         $this->assertTrue($ip->isVersion(6));
@@ -114,7 +115,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidIpAddresses()
      */
-    public function testIsVersionOnlyReturnsFalseFor4($value)
+    public function testIsVersionOnlyReturnsFalseFor4($value): void
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isVersion(4));
@@ -124,7 +125,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidIpAddresses()
      */
-    public function testIsVersion6AlwaysReturnsTrue($value)
+    public function testIsVersion6AlwaysReturnsTrue($value): void
     {
         $ip = IP::factory($value);
         $this->assertTrue($ip->isVersion6());
@@ -134,7 +135,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidIpAddresses()
      */
-    public function testIsVersion4AlwaysReturnsFalse($value)
+    public function testIsVersion4AlwaysReturnsFalse($value): void
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isVersion4());
@@ -144,7 +145,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidCidrValues()
      */
-    public function testCidrMasks($cidr, $expectedMaskHex)
+    public function testCidrMasks($cidr, $expectedMaskHex): void
     {
         $ip = IP::factory('::1');
         $reflect = new \ReflectionClass($ip);
@@ -159,26 +160,42 @@ class IPv6Test extends TestCase
      * @expectedException \Darsyn\IP\Exception\InvalidCidrException
      * @expectedExceptionMessage The CIDR supplied is not valid; it must be an integer between 0 and 128.
      */
-    public function testExceptionIsThrownFromInvalidCidrValues($cidr)
+    public function testExceptionIsThrownFromInvalidCidrValues($cidr): void
     {
         $ip = IP::factory('::1');
-        $reflect = new \ReflectionClass($ip);
-        $method = $reflect->getMethod('generateBinaryMask');
-        $method->setAccessible(true);
+        // Create a wrapper bound to the AbstractIP class to access the
+        // protected method. Use this method instead of reflection because
+        // invoking a ReflectionMethod does not adhere to strict typing.
+        $generateBinaryMask = (function ($cidr): string {
+            return $this->generateBinaryMask($cidr, 16);
+        })->bindTo($ip, $ip);
+
         try {
-            $method->invoke($ip, $cidr, 16);
+            /** @var string $mask */
+            $mask = $generateBinaryMask($cidr);
+            $this->fail(sprintf(
+                'Mask "%s" generated successfully from %s evaluated to %s, expected failure.',
+                Binary::toHex($mask),
+                var_export($cidr, true),
+                var_export((int) $cidr, true)
+            ));
         } catch (InvalidCidrException $e) {
             $this->assertSame($cidr, $e->getSuppliedCidr());
             throw $e;
+        } catch (\TypeError $e) {
+            $this->assertNotInternalType('int', $cidr);
+            // If a TypeError is thrown, it means that CIDR is the wrong data
+            // type so therefore automatically invalid. Throw the appropriate
+            // exception here so that PHPUnit can pick it up.
+            throw new InvalidCidrException(0, 16, $e);
         }
-        $this->fail();
     }
 
     /**
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getNetworkIpAddresses()
      */
-    public function testNetworkIp($expected, $cidr)
+    public function testNetworkIp($expected, $cidr): void
     {
         $ip = IP::factory('2001:db8::a60:8a2e:370:7334');
         $this->assertSame($expected, $ip->getNetworkIp($cidr)->getCompactedAddress());
@@ -188,7 +205,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getBroadcastIpAddresses()
      */
-    public function testBroadcastIp($expected, $cidr)
+    public function testBroadcastIp($expected, $cidr): void
     {
         $ip = IP::factory('2001:db8::a60:8a2e:370:7334');
         $this->assertSame($expected, $ip->getBroadcastIp($cidr)->getCompactedAddress());
@@ -198,7 +215,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidInRangeIpAddresses()
      */
-    public function testInRange($first, $second, $cidr)
+    public function testInRange($first, $second, $cidr): void
     {
         $first = IP::factory($first);
         $second = IP::factory($second);
@@ -208,7 +225,7 @@ class IPv6Test extends TestCase
     /**
      * @test
      */
-    public function testDifferentVersionsAreNotInRange()
+    public function testDifferentVersionsAreNotInRange(): void
     {
         $ip = IP::factory('::12.34.56.78');
         $other = IPv4::factory('12.34.56.78');
@@ -219,7 +236,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getMappedIpAddresses()
      */
-    public function testIsMapped($value, $isMapped)
+    public function testIsMapped($value, $isMapped): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isMapped, $ip->isMapped());
@@ -229,7 +246,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getDerivedIpAddresses()
      */
-    public function testIsDerived($value, $isDerived)
+    public function testIsDerived($value, $isDerived): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isDerived, $ip->isDerived());
@@ -239,7 +256,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getCompatibleIpAddresses()
      */
-    public function testIsCompatible($value, $isCompatible)
+    public function testIsCompatible($value, $isCompatible): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isCompatible, $ip->isCompatible());
@@ -249,7 +266,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidIpAddresses()
      */
-    public function testIsEmbeddedAlwaysReturnsFalse($value)
+    public function testIsEmbeddedAlwaysReturnsFalse($value): void
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isEmbedded());
@@ -259,7 +276,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getLinkLocalIpAddresses()
      */
-    public function testIsLinkLocal($value, $isLinkLocal)
+    public function testIsLinkLocal($value, $isLinkLocal): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isLinkLocal, $ip->isLinkLocal());
@@ -269,7 +286,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getLoopbackIpAddresses()
      */
-    public function testIsLoopback($value, $isLoopback)
+    public function testIsLoopback($value, $isLoopback): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isLoopback, $ip->isLoopback());
@@ -279,7 +296,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getMulticastIpAddresses()
      */
-    public function testIsMulticast($value, $isMulticast)
+    public function testIsMulticast($value, $isMulticast): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isMulticast, $ip->isMulticast());
@@ -290,7 +307,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getPrivateUseIpAddresses()
      */
-    public function testIsPrivateUse($value, $isPrivateUse)
+    public function testIsPrivateUse($value, $isPrivateUse): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isPrivateUse, $ip->isPrivateUse());
@@ -300,7 +317,7 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getUnspecifiedIpAddresses()
      */
-    public function testIsUnspecified($value, $isUnspecified)
+    public function testIsUnspecified($value, $isUnspecified): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isUnspecified, $ip->isUnspecified());

--- a/tests/Version/MultiTest.php
+++ b/tests/Version/MultiTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\Version;
 
@@ -17,7 +17,7 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getValidIpAddresses()
      */
-    public function testInstantiationWithValidAddresses($value)
+    public function testInstantiationWithValidAddresses($value): void
     {
         $ip = IP::factory($value);
         $this->assertInstanceOf(IpInterface::class, $ip);
@@ -30,7 +30,7 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getValidBinarySequences()
      */
-    public function testBinarySequenceIsTheSameOnceInstantiated($value)
+    public function testBinarySequenceIsTheSameOnceInstantiated($value): void
     {
         $ip = IP::factory($value);
         $this->assertSame($value, $ip->getBinary());
@@ -40,7 +40,7 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getValidProtocolIpAddresses()
      */
-    public function testProtocolNotationConvertsToCorrectBinarySequence($value, $hex)
+    public function testProtocolNotationConvertsToCorrectBinarySequence($value, $hex): void
     {
         $ip = IP::factory($value);
         $this->assertSame($hex, unpack('H*hex', $ip->getBinary())['hex']);
@@ -52,7 +52,7 @@ class MultiTest extends TestCase
      * @expectedException \Darsyn\IP\Exception\InvalidIpAddressException
      * @expectedExceptionMessage The IP address supplied is not valid.
      */
-    public function testExceptionIsThrownOnInstantiationWithInvalidAddresses($value)
+    public function testExceptionIsThrownOnInstantiationWithInvalidAddresses($value): void
     {
         try {
             $ip = IP::factory($value);
@@ -67,7 +67,7 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getValidIpAddresses()
      */
-    public function testGetBinaryAlwaysReturnsA16ByteString($value)
+    public function testGetBinaryAlwaysReturnsA16ByteString($value): void
     {
         $ip = IP::factory($value);
         $this->assertSame(16, strlen(bin2hex($ip->getBinary())) / 2);
@@ -77,7 +77,7 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getValidIpAddresses()
      */
-    public function testGetCompactedAddressReturnsCorrectString($value, $hex, $expanded, $compacted)
+    public function testGetCompactedAddressReturnsCorrectString($value, $hex, $expanded, $compacted): void
     {
         $ip = IP::factory($value);
         $this->assertSame($compacted, $ip->getCompactedAddress());
@@ -87,7 +87,7 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getValidProtocolIpAddresses()
      */
-    public function testGetExpandedAddressReturnsCorrectString($value, $hex, $expanded)
+    public function testGetExpandedAddressReturnsCorrectString($value, $hex, $expanded): void
     {
         $ip = IP::factory($value);
         $this->assertSame($expanded, $ip->getExpandedAddress());
@@ -97,7 +97,7 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getValidIpVersion4Addresses()
      */
-    public function testDotAddressReturnsCorrectString($value, $hex, $expanded, $compacted, $dot)
+    public function testDotAddressReturnsCorrectString($value, $hex, $expanded, $compacted, $dot): void
     {
         $ip = IP::factory($value);
         $this->assertSame($dot, $ip->getDotAddress());
@@ -108,7 +108,7 @@ class MultiTest extends TestCase
      * @expectedException \Darsyn\IP\Exception\WrongVersionException
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getValidIpVersion6Addresses()
      */
-    public function testDotAddressThrowsExceptionForNonVersion4Addresses($value)
+    public function testDotAddressThrowsExceptionForNonVersion4Addresses($value): void
     {
         try {
             $ip = IP::factory($value);
@@ -126,7 +126,7 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getNetworkIpAddresses()
      */
-    public function testNetworkIp($initial, $expected, $cidr)
+    public function testNetworkIp($initial, $expected, $cidr): void
     {
         $ip = IP::factory($initial);
         $this->assertSame($expected, $ip->getNetworkIp($cidr)->getProtocolAppropriateAddress());
@@ -136,7 +136,7 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getBroadcastIpAddresses()
      */
-    public function testBroadcastIp($initial, $expected, $cidr)
+    public function testBroadcastIp($initial, $expected, $cidr): void
     {
         $ip = IP::factory($initial);
         $this->assertSame($expected, $ip->getBroadcastIp($cidr)->getProtocolAppropriateAddress());
@@ -146,7 +146,7 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getValidInRangeIpAddresses()
      */
-    public function testInRange($first, $second, $cidr)
+    public function testInRange($first, $second, $cidr): void
     {
         $first = IP::factory($first);
         $second = IP::factory($second);
@@ -157,7 +157,7 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getLinkLocalIpAddresses()
      */
-    public function testIsLinkLocal($value, $isLinkLocal)
+    public function testIsLinkLocal($value, $isLinkLocal): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isLinkLocal, $ip->isLinkLocal());
@@ -167,7 +167,7 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getLoopbackIpAddresses()
      */
-    public function testIsLoopback($value, $isLoopback)
+    public function testIsLoopback($value, $isLoopback): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isLoopback, $ip->isLoopback());
@@ -177,7 +177,7 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getMulticastIpAddresses()
      */
-    public function testIsMulticast($value, $isMulticast)
+    public function testIsMulticast($value, $isMulticast): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isMulticast, $ip->isMulticast());
@@ -188,7 +188,7 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getPrivateUseIpAddresses()
      */
-    public function testIsPrivateUse($value, $isPrivateUse)
+    public function testIsPrivateUse($value, $isPrivateUse): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isPrivateUse, $ip->isPrivateUse());
@@ -198,7 +198,7 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getUnspecifiedIpAddresses()
      */
-    public function testIsUnspecified($value, $isUnspecified)
+    public function testIsUnspecified($value, $isUnspecified): void
     {
         $ip = IP::factory($value);
         $this->assertSame($isUnspecified, $ip->isUnspecified());


### PR DESCRIPTION
Make a start on upgrading the codebase with PHP `7.1+` features, ready for PHP `5.6.x` support to end on 31st December 2018.

Preparing to move to another continent. This took longer than expected. Ready for review.