### PR TITLE
Expanded IPv6 Formatter

### DIFF
--- a/src/Formatter/ConsistentFormatter.php
+++ b/src/Formatter/ConsistentFormatter.php
@@ -24,7 +24,7 @@ class ConsistentFormatter extends NativeFormatter
         throw new FormatException($binary);
     }
 
-    private function ntopVersion6($hex)
+    protected function ntopVersion6($hex)
     {
         $parts = \str_split($hex, 4);
         $zeroes = \array_map(function ($part) {

--- a/src/Formatter/ExpandedIpV6Formatter.php
+++ b/src/Formatter/ExpandedIpV6Formatter.php
@@ -2,60 +2,11 @@
 
 namespace Darsyn\IP\Formatter;
 
-use Darsyn\IP\Binary;
-use Darsyn\IP\Exception\Formatter\FormatException;
-
-class ExpandedIpV6Formatter extends NativeFormatter
+class ExpandedIpV6Formatter extends ConsistentFormatter
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function ntop($binary)
+    protected function ntopVersion6($hex)
     {
-        if (\is_string($binary)) {
-            $length = Binary::getLength($binary);
-            if ($length === 16) {
-                return $this->ntopVersion6(Binary::toHex($binary));
-            }
-            if ($length === 4) {
-                return $this->ntopVersion4($binary);
-            }
-        }
-        throw new FormatException($binary);
-    }
-
-    private function ntopVersion6($hex)
-    {
-        $parts = \str_split($hex, 4);
-        $zeroes = \array_map(function ($part) {
-            return $part === '0000';
-        }, $parts);
-        $length = $i = 0;
-        $sequences = [];
-        foreach ($zeroes as $zero) {
-            $length = $zero ? ++$length : 0;
-            $sequences[++$i] = $length;
-        }
-        $maxLength = \max($sequences);
-        $position = \array_search($maxLength, $sequences, true) - $maxLength;
-        $parts = \array_map(function ($part) {
-            return \ltrim($part, '0') ?: '0';
-        }, $parts);
-        if ($maxLength > 0) {
-            \array_splice($parts, $position, $maxLength, ':');
-        }
-
-        return $this->expandIp(\str_pad(\preg_replace('/\:{2,}/', '::', \implode(':', $parts)), 2, ':'));
-    }
-
-    private function ntopVersion4($binary)
-    {
-        return \inet_ntop(\pack('A4', $binary));
-    }
-
-    private function expandIp($ip)
-    {
-        $hex = unpack("H*hex", inet_pton($ip));
+        $hex = unpack("H*hex", inet_pton(parent::ntopVersion6($hex)));
         return substr(preg_replace("/([A-f0-9]{4})/", "$1:", $hex['hex']), 0, -1);
     }
 }

--- a/tests/Formatter/ExpandedIpV6FormatterTest.php
+++ b/tests/Formatter/ExpandedIpV6FormatterTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace Darsyn\IP\Tests\Formatter;
+
+use Darsyn\IP\Exception\Formatter\FormatException;
+use Darsyn\IP\Formatter\ExpandedIpV6Formatter as Formatter;
+use Darsyn\IP\Formatter\ProtocolFormatterInterface;
+use Darsyn\IP\Tests\TestCase;
+
+class ExpandedIpV6FormatterTest extends TestCase
+{
+    /** @var \Darsyn\IP\Formatter\ProtocolFormatterInterface $formatter */
+    private $formatter;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->formatter = new Formatter;
+    }
+
+    /**
+     * @test
+     */
+    public function testFormatterIsInstanceOfInterface()
+    {
+        $this->assertInstanceOf(ProtocolFormatterInterface::class, $this->formatter);
+    }
+
+    /**
+     * @test
+     * @expectedException \Darsyn\IP\Exception\Formatter\FormatException
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Formatter\ConsistentFormatter::getInvalidBinarySequences()
+     */
+    public function testFormatterThrowsExceptionOnInvalidBinarySequences($value)
+    {
+        try {
+            $this->formatter->ntop($value);
+        } catch (FormatException $e) {
+            $this->assertSame($value, $e->getSuppliedBinary());
+            throw $e;
+        }
+        $this->fail();
+    }
+
+    public function testFormatterExapndsIpV6Address()
+    {
+        $ip = pack('H*', '20010db8000000000a608a2e03707334'); // 2001:db8::a60:8a2e:370:7334
+        $this->assertEquals('2001:0db8:0000:0000:0a60:8a2e:0370:7334', $this->formatter->ntop($ip));
+    }
+}


### PR DESCRIPTION
This PR adds a new Formatter that outputs IPv6 addresses in their expanded form.

I didn't squash the commits intentionally so you can see the implementation where `ConsistentFormatter::ntopVersion6()` remains a private function.