### PR TITLE
Support for 8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ matrix:
         -   name: '8.0'
             php: '8.0'
             env: 'PHPUNIT=9.5'
-    allow_failures:
         -   name: '8.1'
             php: '8.1'
             env: 'PHPUNIT=9.5'


### PR DESCRIPTION
PHP 8.1 Has Been Released; don't allow failures on 8.1

This will be merged either:
- When Travis CI adds support for PHP 8.1
- I eventually switch to GitHub Actions for CI builds.