### PR TITLE
Add ".gitattributes" File

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto
+
+/.github/ export-ignore
+/docs/ export-ignore
+/tests/ export-ignore
+/mkdocs.yaml export-ignore


### PR DESCRIPTION
Ignore tests and documentation when exporting Git archive (eg, download package via [Composer](https://getcomposer.org)).