### PR TITLE
Human-readable IP address in WrongVersionException

### DIFF
--- a/src/Exception/InvalidIpAddressException.php
+++ b/src/Exception/InvalidIpAddressException.php
@@ -10,7 +10,7 @@ class InvalidIpAddressException extends IpException
     /**
      * Constructor
      *
-     * @param string $ip
+     * @param scalar $ip
      * @param \Exception|null $previous
      */
     public function __construct($ip, \Exception $previous = null)

--- a/src/Exception/WrongVersionException.php
+++ b/src/Exception/WrongVersionException.php
@@ -13,7 +13,7 @@ class WrongVersionException extends InvalidIpAddressException
     /**
      * @param int $expected
      * @param int $actual
-     * @param string $ip
+     * @param scalar $ip
      * @param \Exception|null $previous
      */
     public function __construct($expected, $actual, $ip, \Exception $previous = null)

--- a/src/Version/Multi.php
+++ b/src/Version/Multi.php
@@ -118,7 +118,7 @@ class Multi extends IPv6 implements MultiVersionInterface
                 throw new Exception\IpException('An unknown error occured internally.', 0, $e);
             }
         }
-        throw new Exception\WrongVersionException(4, 6, $this->getBinary());
+        throw new Exception\WrongVersionException(4, 6, (string) $this);
     }
 
     /** {@inheritDoc} */

--- a/tests/Version/MultiTest.php
+++ b/tests/Version/MultiTest.php
@@ -80,7 +80,7 @@ class MultiTest extends TestCase
      */
     public function testExceptionIsThrownOnInstantiationWithInvalidAddresses($value)
     {
-        $this->expectException(\Darsyn\IP\Exception\InvalidIpAddressException::class);
+        $this->expectException(InvalidIpAddressException::class);
         $this->expectExceptionMessage('The IP address supplied is not valid.');
         try {
             $ip = IP::factory($value);
@@ -88,7 +88,6 @@ class MultiTest extends TestCase
             $this->assertSame($value, $e->getSuppliedIp());
             throw $e;
         }
-        $this->fail();
     }
 
     /**
@@ -142,12 +141,11 @@ class MultiTest extends TestCase
             $ip = IP::factory($value);
             $ip->getDotAddress();
         } catch (WrongVersionException $e) {
-            $this->assertSame($ip->getBinary(), $e->getSuppliedIp());
+            $this->assertSame((string) $ip, $e->getSuppliedIp());
             $this->assertSame(4, $e->getExpectedVersion());
             $this->assertSame(6, $e->getActualVersion());
             throw $e;
         }
-        $this->fail();
     }
 
     /**


### PR DESCRIPTION
`WrongVersionException` now returns human-readable IP address string instead of binary where possible.