### PR TITLE
Update IpInterface::inRange()

### DIFF
--- a/src/AbstractIP.php
+++ b/src/AbstractIP.php
@@ -170,7 +170,7 @@ abstract class AbstractIP implements IpInterface
      */
     protected function isSameByteLength(IpInterface $ip)
     {
-        return Binary::getLength($this->getBinary()) === Binary::getLength($ip->getBinary());
+        return MbString::getLength($this->getBinary()) === MbString::getLength($ip->getBinary());
     }
 
     /**

--- a/src/IpInterface.php
+++ b/src/IpInterface.php
@@ -75,11 +75,13 @@ interface IpInterface
      *
      * Returns a boolean value depending on whether the IP address in question
      * is within the range of the target IP/CIDR combination.
-     * Comparing two IP's of different versions will *always* return false.
+     * Comparing two IPs of different byte-lengths (IPv4 vs IPv6/IPv4-embedded)
+     * will throw a WrongVersionException.
      *
      * @param \Darsyn\IP\IpInterface $ip
      * @param int $cidr
      * @throws \Darsyn\IP\Exception\InvalidCidrException
+     * @throws \Darsyn\IP\Exception\WrongVersionException
      * @return bool
      */
     public function inRange(IpInterface $ip, $cidr);

--- a/tests/Version/IPv4Test.php
+++ b/tests/Version/IPv4Test.php
@@ -4,6 +4,7 @@ namespace Darsyn\IP\Tests\Version;
 
 use Darsyn\IP\Exception\InvalidCidrException;
 use Darsyn\IP\Exception\InvalidIpAddressException;
+use Darsyn\IP\Exception\WrongVersionException;
 use Darsyn\IP\IpInterface;
 use Darsyn\IP\Version\IPv4 as IP;
 use Darsyn\IP\Version\IPv6;
@@ -199,11 +200,12 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getInvalidCidrValues()
      */
-    public function testInRangeReturnsFalseInsteadOfExceptionOnInvalidCidr($cidr)
+    public function testInRangeThrowsExceptionOnInvalidCidr($cidr)
     {
         $first = IP::factory('12.34.56.78');
         $second = IP::factory('12.34.56.78');
-        $this->assertFalse($first->inRange($second, $cidr));
+        $this->expectException(InvalidCidrException::class);
+        $first->inRange($second, $cidr);
     }
 
     /**
@@ -213,7 +215,8 @@ class IPv4Test extends TestCase
     {
         $ip = IP::factory('12.34.56.78');
         $other = IPv6::factory('::12.34.56.78');
-        $this->assertFalse($ip->inRange($other, 0));
+        $this->expectException(WrongVersionException::class);
+        $ip->inRange($other, 0);
     }
 
     /**

--- a/tests/Version/IPv6Test.php
+++ b/tests/Version/IPv6Test.php
@@ -4,6 +4,7 @@ namespace Darsyn\IP\Tests\Version;
 
 use Darsyn\IP\Exception\InvalidCidrException;
 use Darsyn\IP\Exception\InvalidIpAddressException;
+use Darsyn\IP\Exception\WrongVersionException;
 use Darsyn\IP\IpInterface;
 use Darsyn\IP\Strategy\Mapped;
 use Darsyn\IP\Version\IPv4;
@@ -241,7 +242,8 @@ class IPv6Test extends TestCase
     {
         $ip = IP::factory('::12.34.56.78');
         $other = IPv4::factory('12.34.56.78');
-        $this->assertFalse($ip->inRange($other, 0));
+        $this->expectException(WrongVersionException::class);
+        $ip->inRange($other, 0);
     }
 
     /**


### PR DESCRIPTION
- Fix bug when comparing IPv6 and IPv4-embedded addresses (incorrect network addresses compared).
- Will now throw `InvalidCidrException` on an invalid CIDR, instead of just returning `false`.
- Will now throw `WrongVersionException` on comparing two IPs of differing byte-length (IPv4 vs IPv6/IPv4-embedded).
- Helper methods in `Multi` now correctly detect IPv4 according to embedding strategy and CIDR.

Do not merge until after #76 (update `AbstractIP::isSameByteLength()` to use `Darsyn\IP\Util\MbString`).