### PR TITLE
Add @return PHPDoc annotations to AbstractType.php

### DIFF
--- a/src/Doctrine/AbstractType.php
+++ b/src/Doctrine/AbstractType.php
@@ -36,6 +36,7 @@ abstract class AbstractType extends Type
 
     /**
      * {@inheritdoc}
+     * @return string
      */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform)
     {
@@ -45,6 +46,7 @@ abstract class AbstractType extends Type
     /**
      * {@inheritdoc}
      * @throws \Doctrine\DBAL\Types\ConversionException
+     * @return mixed
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
@@ -77,6 +79,7 @@ abstract class AbstractType extends Type
     /**
      * {@inheritdoc}
      * @throws \Doctrine\DBAL\Types\ConversionException
+     * @return mixed
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -122,6 +125,7 @@ abstract class AbstractType extends Type
 
     /**
      * {@inheritdoc}
+     * @return string
      */
     public function getName()
     {
@@ -130,6 +134,7 @@ abstract class AbstractType extends Type
 
     /**
      * {@inheritdoc}
+     * @return int
      */
     public function getBindingType()
     {
@@ -138,6 +143,7 @@ abstract class AbstractType extends Type
 
     /**
      * {@inheritdoc}
+     * @return bool
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {


### PR DESCRIPTION
Get rid of error messages like:

```
2022-03-06T21:58:26+01:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::getSQLDeclaration()" might add "string" as a native return type declaration in the future. Do the same in child class "Darsyn\IP\Doctrine\AbstractType" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-06T21:58:26+01:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::convertToPHPValue()" might add "mixed" as a native return type declaration in the future. Do the same in child class "Darsyn\IP\Doctrine\AbstractType" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-06T21:58:26+01:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::convertToDatabaseValue()" might add "mixed" as a native return type declaration in the future. Do the same in child class "Darsyn\IP\Doctrine\AbstractType" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-06T21:58:26+01:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::getName()" might add "string" as a native return type declaration in the future. Do the same in child class "Darsyn\IP\Doctrine\AbstractType" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-06T21:58:26+01:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::getBindingType()" might add "int" as a native return type declaration in the future. Do the same in child class "Darsyn\IP\Doctrine\AbstractType" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-06T21:58:26+01:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::requiresSQLCommentHint()" might add "bool" as a native return type declaration in the future. Do the same in child class "Darsyn\IP\Doctrine\AbstractType" now to avoid errors or add an explicit @return annotation to suppress this message.

```

I used PHPDoc annotations and not explicit return types to keep compatibility with PHP5.6+ as your composer conf file says. Please merge, I get these errors all the time in my console. Thanks