### PR TITLE
Doctrine/DBAL 4 conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,11 @@
     },
     "require-dev": {
         "ext-pdo": "*",
-        "doctrine/dbal": "^2.3",
+        "doctrine/dbal": "^2.3 || ^3",
         "phpunit/phpunit": "*"
+    },
+    "conflict": {
+        "doctrine/dbal": ">=4“
     },
     "prefer-stable": true,
     "config": {


### PR DESCRIPTION
Doctrine DBAL v4 requires PHP 8 and contains some changes that break compatibility with IP column type definition. DBAL 2-3 and ORM v3 works fine. To fix such problems we must mark DBAL v4 as conflict.