### PR TITLE
Explicitly mark nullable values as nullable

### DIFF
--- a/src/Exception/Formatter/FormatException.php
+++ b/src/Exception/Formatter/FormatException.php
@@ -13,7 +13,7 @@ class FormatException extends IpException
      * @param string $binary
      * @param \Exception|null $previous
      */
-    public function __construct($binary, \Exception $previous = null)
+    public function __construct($binary, ?\Exception $previous = null)
     {
         $this->binary = $binary;
         parent::__construct('Cannot format invalid binary sequence; must be a string either 4 or 16 bytes long.', 0, $previous);

--- a/src/Exception/InvalidCidrException.php
+++ b/src/Exception/InvalidCidrException.php
@@ -14,7 +14,7 @@ class InvalidCidrException extends IpException
      * @param mixed $addressLengthInBytes
      * @param \Exception|null $previous
      */
-    public function __construct($cidr, $addressLengthInBytes, \Exception $previous = null)
+    public function __construct($cidr, $addressLengthInBytes, ?\Exception $previous = null)
     {
         $this->cidr = $cidr;
         $message = 'The supplied CIDR is not valid; it must be an integer ';

--- a/src/Exception/InvalidIpAddressException.php
+++ b/src/Exception/InvalidIpAddressException.php
@@ -13,7 +13,7 @@ class InvalidIpAddressException extends IpException
      * @param scalar $ip
      * @param \Exception|null $previous
      */
-    public function __construct($ip, \Exception $previous = null)
+    public function __construct($ip, ?\Exception $previous = null)
     {
         $this->ip = $ip;
         parent::__construct('The IP address supplied is not valid.', 0, $previous);

--- a/src/Exception/Strategy/ExtractionException.php
+++ b/src/Exception/Strategy/ExtractionException.php
@@ -18,7 +18,7 @@ class ExtractionException extends IpException
      * @param \Darsyn\IP\Strategy\EmbeddingStrategyInterface $embeddingStrategy
      * @param \Exception|null $previous
      */
-    public function __construct($binary, EmbeddingStrategyInterface $embeddingStrategy, \Exception $previous = null)
+    public function __construct($binary, EmbeddingStrategyInterface $embeddingStrategy, ?\Exception $previous = null)
     {
         $this->binary = $binary;
         $this->embeddingStrategy = $embeddingStrategy;

--- a/src/Exception/Strategy/PackingException.php
+++ b/src/Exception/Strategy/PackingException.php
@@ -18,7 +18,7 @@ class PackingException extends IpException
      * @param EmbeddingStrategyInterface $embeddingStrategy
      * @param \Exception|null $previous
      */
-    public function __construct($binary, EmbeddingStrategyInterface $embeddingStrategy, \Exception $previous = null)
+    public function __construct($binary, EmbeddingStrategyInterface $embeddingStrategy, ?\Exception $previous = null)
     {
         $this->binary = $binary;
         $this->embeddingStrategy = $embeddingStrategy;

--- a/src/Exception/WrongVersionException.php
+++ b/src/Exception/WrongVersionException.php
@@ -16,7 +16,7 @@ class WrongVersionException extends InvalidIpAddressException
      * @param scalar $ip
      * @param \Exception|null $previous
      */
-    public function __construct($expected, $actual, $ip, \Exception $previous = null)
+    public function __construct($expected, $actual, $ip, ?\Exception $previous = null)
     {
         $this->expected = $expected;
         $this->actual = $actual;

--- a/src/Version/IPv6.php
+++ b/src/Version/IPv6.php
@@ -54,7 +54,7 @@ class IPv6 extends AbstractIP implements Version6Interface
      * @throws \Darsyn\IP\Exception\WrongVersionException
      * @return static
      */
-    public static function fromEmbedded($ip, EmbeddingStrategyInterface $strategy = null)
+    public static function fromEmbedded($ip, ?EmbeddingStrategyInterface $strategy = null)
     {
         return new static(Multi::factory($ip, $strategy)->getBinary());
     }

--- a/src/Version/Multi.php
+++ b/src/Version/Multi.php
@@ -61,7 +61,7 @@ class Multi extends IPv6 implements MultiVersionInterface
      * {@inheritDoc}
      * @param \Darsyn\IP\Strategy\EmbeddingStrategyInterface $strategy
      */
-    public static function factory($ip, EmbeddingStrategyInterface $strategy = null)
+    public static function factory($ip, ?EmbeddingStrategyInterface $strategy = null)
     {
         // We need a strategy to pack version 4 addresses.
         $strategy = $strategy ?: self::getDefaultEmbeddingStrategy();
@@ -85,7 +85,7 @@ class Multi extends IPv6 implements MultiVersionInterface
      * {@inheritDoc}
      * @param \Darsyn\IP\Strategy\EmbeddingStrategyInterface|null $strategy
      */
-    protected function __construct($ip, EmbeddingStrategyInterface $strategy = null)
+    protected function __construct($ip, ?EmbeddingStrategyInterface $strategy = null)
     {
         // Fallback to default in case this instance was created from static in
         // the abstract IP class.


### PR DESCRIPTION
Fixes PHP 8.4 deprecation notices.

To view these notices before this commit, run tests with `--display-deprecations` flag on PHP 8.4.