### PR TITLE
Runtime compat for `5.x`

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -1,30 +1,30 @@
-name: "Static Analysis"
+name: 'Static Analysis'
 
 on:
   pull_request:
     branches:
-      - 'develop'
+      - '5.x'
+      - '6.x'
   push:
     branches:
-      - 'develop'
-      - 'master'
+      - '5.x'
+      - '6.x'
 
 jobs:
 
   phpstan:
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-24.04'
     strategy:
       matrix:
         php:
-            - '7.4'
-            - '8.3'
-            - '8.4'
+          - '7.4'
+          - '8.3'
     steps:
-      - uses: 'actions/checkout@v2'
+      - uses: 'actions/checkout@v6'
       - uses: 'shivammathur/setup-php@v2'
         with:
           php-version: '${{ matrix.php }}'
-      - uses: 'ramsey/composer-install@v2'
+      - uses: 'ramsey/composer-install@v4'
         with:
           dependency-versions: 'highest'
       # Require PHPStan via command-line instead of adding to Composer's

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -1,18 +1,19 @@
-name: "Linting and Unit Tests"
+name: 'Linting and Unit Tests'
 
 on:
   pull_request:
     branches:
-      - 'develop'
+      - '5.x'
+      - '6.x'
   push:
     branches:
-      - 'develop'
-      - 'master'
+      - '5.x'
+      - '6.x'
 
 jobs:
 
   syntax-linting:
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     strategy:
       matrix:
         php:
@@ -26,16 +27,15 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
-          - '8.4'
     steps:
-      - uses: 'actions/checkout@v2'
+      - uses: 'actions/checkout@v6'
       - uses: 'shivammathur/setup-php@v2'
         with:
           php-version: '${{ matrix.php }}'
       - run: 'find src/ -type f -name "*.php" -print0 | xargs -0 -n1 -P4 php -d"error_reporting=E_ALL&~E_DEPRECATED" -l -n | (! grep -v "No syntax errors detected" )'
 
   unit-testing:
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     strategy:
       matrix:
         php:
@@ -49,13 +49,12 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
-          - '8.4'
     steps:
-      - uses: 'actions/checkout@v2'
+      - uses: 'actions/checkout@v6'
       - uses: 'shivammathur/setup-php@v2'
         with:
           php-version: '${{ matrix.php }}'
-      - uses: 'ramsey/composer-install@v2'
+      - uses: 'ramsey/composer-install@v4'
         with:
           dependency-versions: 'highest'
       - run: './vendor/bin/phpunit --bootstrap="tests/bootstrap.php" --test-suffix="Test.php" tests'

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Full documentation is available in the [`docs/`](docs/) folder.
 ## Compatibility
 
 This library has extensive test coverage using PHPUnit on PHP versions: `5.6`,
-`7.0`, `7.1`, `7.2`, `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, `8.3` and `8.4`.
+`7.0`, `7.1`, `7.2`, `7.3`, `7.4`, `8.0`, `8.1`, `8.2` and `8.3`.
 
 Static analysis is performed with PHPStan at `max` level on PHP `8.4`, using
 core, bleeding edge, and deprecation rules.

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         }
     },
     "require": {
-        "php-64bit": ">=5.6",
-        "php-ipv6": ">=5.6",
+        "php-64bit": ">=5.6,<8.4",
+        "php-ipv6": ">=5.6,<8.4",
         "ext-ctype": "*"
     },
     "autoload-dev": {

--- a/tests/Util/BinaryTest.php
+++ b/tests/Util/BinaryTest.php
@@ -63,11 +63,12 @@ class BinaryTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Util\Binary::getBinaryData()
      * @param string $hex
+     * @param string $humanReadable
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(BinaryDataProvider::class, 'getBinaryData')]
-    public function testHexCanConvertAndBackAgain($hex)
+    public function testHexCanConvertAndBackAgain($hex, $humanReadable)
     {
         $converted = Binary::fromHex($hex);
         $this->assertSame(strtolower($hex), Binary::toHex($converted));

--- a/tests/Version/IPv4Test.php
+++ b/tests/Version/IPv4Test.php
@@ -237,7 +237,6 @@ class IPv4Test extends TestCase
         $method->setAccessible(true);
         try {
             $method->invoke($ip, $cidr, 4);
-        // @phpstan-ignore catch.neverThrown
         } catch (InvalidCidrException $e) {
             $this->assertSame($cidr, $e->getSuppliedCidr());
             throw $e;

--- a/tests/Version/IPv4Test.php
+++ b/tests/Version/IPv4Test.php
@@ -19,11 +19,13 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      * @param string $value
+     * @param string $expectedHex
+     * @param string $expectedDot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv4DataProvider::class, 'getValidIpAddresses')]
-    public function testInstantiationWithValidAddresses($value)
+    public function testInstantiationWithValidAddresses($value, $expectedHex, $expectedDot)
     {
         $ip = IP::factory($value);
         $this->assertInstanceOf(IpInterface::class, $ip);
@@ -34,11 +36,13 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidBinarySequences()
      * @param string $value
+     * @param string $expectedHex
+     * @param string $expectedDot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv4DataProvider::class, 'getValidBinarySequences')]
-    public function testBinarySequenceIsTheSameOnceInstantiated($value)
+    public function testBinarySequenceIsTheSameOnceInstantiated($value, $expectedHex, $expectedDot)
     {
         $ip = IP::factory($value);
         $this->assertSame($value, $ip->getBinary());
@@ -49,11 +53,12 @@ class IPv4Test extends TestCase
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidProtocolIpAddresses()
      * @param string $value
      * @param string $expectedHex
+     * @param string $expectedDot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv4DataProvider::class, 'getValidProtocolIpAddresses')]
-    public function testProtocolNotationConvertsToCorrectBinarySequence($value, $expectedHex)
+    public function testProtocolNotationConvertsToCorrectBinarySequence($value, $expectedHex, $expectedDot)
     {
         $ip = IP::factory($value);
         $actualHex = unpack('H*hex', $ip->getBinary());
@@ -86,11 +91,13 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      * @param string $value
+     * @param string $expectedHex
+     * @param string $expectedDot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv4DataProvider::class, 'getValidIpAddresses')]
-    public function testGetBinaryAlwaysReturnsA4ByteString($value)
+    public function testGetBinaryAlwaysReturnsA4ByteString($value, $expectedHex, $expectedDot)
     {
         $ip = IP::factory($value);
         $this->assertSame(4, strlen(bin2hex($ip->getBinary())) / 2);
@@ -116,11 +123,13 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      * @param string $value
+     * @param string $expectedHex
+     * @param string $expectedDot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv4DataProvider::class, 'getValidIpAddresses')]
-    public function testGetVersionAlwaysReturns4($value)
+    public function testGetVersionAlwaysReturns4($value, $expectedHex, $expectedDot)
     {
         $ip = IP::factory($value);
         $this->assertSame(4, $ip->getVersion());
@@ -130,11 +139,13 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      * @param string $value
+     * @param string $expectedHex
+     * @param string $expectedDot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv4DataProvider::class, 'getValidIpAddresses')]
-    public function testIsVersionOnlyReturnsTrueFor4($value)
+    public function testIsVersionOnlyReturnsTrueFor4($value, $expectedHex, $expectedDot)
     {
         $ip = IP::factory($value);
         $this->assertTrue($ip->isVersion(4));
@@ -144,11 +155,13 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      * @param string $value
+     * @param string $expectedHex
+     * @param string $expectedDot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv4DataProvider::class, 'getValidIpAddresses')]
-    public function testIsVersionOnlyReturnsFalseFor6($value)
+    public function testIsVersionOnlyReturnsFalseFor6($value, $expectedHex, $expectedDot)
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isVersion(6));
@@ -158,11 +171,13 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      * @param string $value
+     * @param string $expectedHex
+     * @param string $expectedDot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv4DataProvider::class, 'getValidIpAddresses')]
-    public function testIsVersion4AlwaysReturnsTrue($value)
+    public function testIsVersion4AlwaysReturnsTrue($value, $expectedHex, $expectedDot)
     {
         $ip = IP::factory($value);
         $this->assertTrue($ip->isVersion4());
@@ -172,11 +187,13 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      * @param string $value
+     * @param string $expectedHex
+     * @param string $expectedDot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv4DataProvider::class, 'getValidIpAddresses')]
-    public function testIsVersion6AlwaysReturnsFalse($value)
+    public function testIsVersion6AlwaysReturnsFalse($value, $expectedHex, $expectedDot)
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isVersion6());
@@ -339,11 +356,13 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      * @param string $value
+     * @param string $expectedHex
+     * @param string $expectedDot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv4DataProvider::class, 'getValidIpAddresses')]
-    public function testIsMappedAlwaysReturnsFalse($value)
+    public function testIsMappedAlwaysReturnsFalse($value, $expectedHex, $expectedDot)
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isMapped());
@@ -353,11 +372,13 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      * @param string $value
+     * @param string $expectedHex
+     * @param string $expectedDot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv4DataProvider::class, 'getValidIpAddresses')]
-    public function testIsDerivedAlwaysReturnsFalse($value)
+    public function testIsDerivedAlwaysReturnsFalse($value, $expectedHex, $expectedDot)
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isDerived());
@@ -367,11 +388,13 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      * @param string $value
+     * @param string $expectedHex
+     * @param string $expectedDot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv4DataProvider::class, 'getValidIpAddresses')]
-    public function testIsCompatibleAlwaysReturnsFalse($value)
+    public function testIsCompatibleAlwaysReturnsFalse($value, $expectedHex, $expectedDot)
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isCompatible());
@@ -381,11 +404,13 @@ class IPv4Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidIpAddresses()
      * @param string $value
+     * @param string $expectedHex
+     * @param string $expectedDot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv4DataProvider::class, 'getValidIpAddresses')]
-    public function testIsEmbeddedAlwaysReturnsFalse($value)
+    public function testIsEmbeddedAlwaysReturnsFalse($value, $expectedHex, $expectedDot)
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isEmbedded());

--- a/tests/Version/IPv6Test.php
+++ b/tests/Version/IPv6Test.php
@@ -296,7 +296,6 @@ class IPv6Test extends TestCase
         $method->setAccessible(true);
         try {
             $method->invoke($ip, $cidr, 16);
-        // @phpstan-ignore catch.neverThrown
         } catch (InvalidCidrException $e) {
             $this->assertSame($cidr, $e->getSuppliedCidr());
             throw $e;

--- a/tests/Version/IPv6Test.php
+++ b/tests/Version/IPv6Test.php
@@ -22,11 +22,14 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidIpAddresses()
      * @param string $value
+     * @param string $hex
+     * @param string $expanded
+     * @param string $compacted
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv6DataProvider::class, 'getValidIpAddresses')]
-    public function testInstantiationWithValidAddresses($value)
+    public function testInstantiationWithValidAddresses($value, $hex, $expanded, $compacted)
     {
         $ip = IP::factory($value);
         $this->assertInstanceOf(IpInterface::class, $ip);
@@ -37,11 +40,14 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidBinarySequences()
      * @param string $value
+     * @param string $hex
+     * @param string $expanded
+     * @param string $compacted
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv6DataProvider::class, 'getValidBinarySequences')]
-    public function testBinarySequenceIsTheSameOnceInstantiated($value)
+    public function testBinarySequenceIsTheSameOnceInstantiated($value, $hex, $expanded, $compacted)
     {
         $ip = IP::factory($value);
         $this->assertSame($value, $ip->getBinary());
@@ -52,11 +58,13 @@ class IPv6Test extends TestCase
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidProtocolIpAddresses()
      * @param string $value
      * @param string $hex
+     * @param string $expanded
+     * @param string $compacted
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv6DataProvider::class, 'getValidProtocolIpAddresses')]
-    public function testProtocolNotationConvertsToCorrectBinarySequence($value, $hex)
+    public function testProtocolNotationConvertsToCorrectBinarySequence($value, $hex, $expanded, $compacted)
     {
         $ip = IP::factory($value);
         $actualHex = unpack('H*hex', $ip->getBinary());
@@ -118,11 +126,14 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidIpAddresses()
      * @param string $value
+     * @param string $hex
+     * @param string $expanded
+     * @param string $compacted
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv6DataProvider::class, 'getValidIpAddresses')]
-    public function testGetBinaryAlwaysReturnsA16ByteString($value)
+    public function testGetBinaryAlwaysReturnsA16ByteString($value, $hex, $expanded, $compacted)
     {
         $ip = IP::factory($value);
         $this->assertSame(16, strlen(bin2hex($ip->getBinary())) / 2);
@@ -151,11 +162,12 @@ class IPv6Test extends TestCase
      * @param string $value
      * @param string $hex
      * @param string $expanded
+     * @param string $compacted
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv6DataProvider::class, 'getValidProtocolIpAddresses')]
-    public function testGetExpandedAddressReturnsCorrectString($value, $hex, $expanded)
+    public function testGetExpandedAddressReturnsCorrectString($value, $hex, $expanded, $compacted)
     {
         $ip = IP::factory($value);
         $this->assertSame($expanded, $ip->getExpandedAddress());
@@ -165,11 +177,14 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidIpAddresses()
      * @param string $value
+     * @param string $hex
+     * @param string $expanded
+     * @param string $compacted
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv6DataProvider::class, 'getValidIpAddresses')]
-    public function testGetVersionAlwaysReturns6($value)
+    public function testGetVersionAlwaysReturns6($value, $hex, $expanded, $compacted)
     {
         $ip = IP::factory($value);
         $this->assertSame(6, $ip->getVersion());
@@ -179,11 +194,14 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidIpAddresses()
      * @param string $value
+     * @param string $hex
+     * @param string $expanded
+     * @param string $compacted
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv6DataProvider::class, 'getValidIpAddresses')]
-    public function testIsVersionOnlyReturnsTrueFor6($value)
+    public function testIsVersionOnlyReturnsTrueFor6($value, $hex, $expanded, $compacted)
     {
         $ip = IP::factory($value);
         $this->assertTrue($ip->isVersion(6));
@@ -193,11 +211,14 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidIpAddresses()
      * @param string $value
+     * @param string $hex
+     * @param string $expanded
+     * @param string $compacted
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv6DataProvider::class, 'getValidIpAddresses')]
-    public function testIsVersionOnlyReturnsFalseFor4($value)
+    public function testIsVersionOnlyReturnsFalseFor4($value, $hex, $expanded, $compacted)
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isVersion(4));
@@ -207,11 +228,14 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidIpAddresses()
      * @param string $value
+     * @param string $hex
+     * @param string $expanded
+     * @param string $compacted
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv6DataProvider::class, 'getValidIpAddresses')]
-    public function testIsVersion6AlwaysReturnsTrue($value)
+    public function testIsVersion6AlwaysReturnsTrue($value, $hex, $expanded, $compacted)
     {
         $ip = IP::factory($value);
         $this->assertTrue($ip->isVersion6());
@@ -221,11 +245,14 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidIpAddresses()
      * @param string $value
+     * @param string $hex
+     * @param string $expanded
+     * @param string $compacted
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv6DataProvider::class, 'getValidIpAddresses')]
-    public function testIsVersion4AlwaysReturnsFalse($value)
+    public function testIsVersion4AlwaysReturnsFalse($value, $hex, $expanded, $compacted)
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isVersion4());
@@ -433,11 +460,14 @@ class IPv6Test extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidIpAddresses()
      * @param string $value
+     * @param string $hex
+     * @param string $expanded
+     * @param string $compacted
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv6DataProvider::class, 'getValidIpAddresses')]
-    public function testIsEmbeddedAlwaysReturnsFalse($value)
+    public function testIsEmbeddedAlwaysReturnsFalse($value, $hex, $expanded, $compacted)
     {
         $ip = IP::factory($value);
         $this->assertFalse($ip->isEmbedded());

--- a/tests/Version/MultiTest.php
+++ b/tests/Version/MultiTest.php
@@ -32,11 +32,15 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getValidIpAddresses()
      * @param string $value
+     * @param string $hex
+     * @param string $expanded
+     * @param string $compacted
+     * @param string $dot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(MultiDataProvider::class, 'getValidIpAddresses')]
-    public function testInstantiationWithValidAddresses($value)
+    public function testInstantiationWithValidAddresses($value, $hex, $expanded, $compacted, $dot)
     {
         $ip = IP::factory($value);
         $this->assertInstanceOf(IpInterface::class, $ip);
@@ -82,11 +86,15 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getValidBinarySequences()
      * @param string $value
+     * @param string $hex
+     * @param string $expanded
+     * @param string $compacted
+     * @param string $dot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(MultiDataProvider::class, 'getValidBinarySequences')]
-    public function testBinarySequenceIsTheSameOnceInstantiated($value)
+    public function testBinarySequenceIsTheSameOnceInstantiated($value, $hex, $expanded, $compacted, $dot)
     {
         $ip = IP::factory($value);
         $this->assertSame($value, $ip->getBinary());
@@ -97,11 +105,14 @@ class MultiTest extends TestCase
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getValidProtocolIpAddresses()
      * @param string $value
      * @param string $hex
+     * @param string $expanded
+     * @param string $compacted
+     * @param string $dot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(MultiDataProvider::class, 'getValidProtocolIpAddresses')]
-    public function testProtocolNotationConvertsToCorrectBinarySequence($value, $hex)
+    public function testProtocolNotationConvertsToCorrectBinarySequence($value, $hex, $expanded, $compacted, $dot)
     {
         $ip = IP::factory($value);
         $actualHex = unpack('H*hex', $ip->getBinary());
@@ -133,11 +144,15 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getValidIpAddresses()
      * @param string $value
+     * @param string $hex
+     * @param string $expanded
+     * @param string $compacted
+     * @param string $dot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(MultiDataProvider::class, 'getValidIpAddresses')]
-    public function testGetBinaryAlwaysReturnsA16ByteString($value)
+    public function testGetBinaryAlwaysReturnsA16ByteString($value, $hex, $expanded, $compacted, $dot)
     {
         $ip = IP::factory($value);
         $this->assertSame(16, strlen(bin2hex($ip->getBinary())) / 2);
@@ -150,11 +165,12 @@ class MultiTest extends TestCase
      * @param string $hex
      * @param string $expanded
      * @param string $compacted
+     * @param string $dot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(MultiDataProvider::class, 'getValidIpAddresses')]
-    public function testGetCompactedAddressReturnsCorrectString($value, $hex, $expanded, $compacted)
+    public function testGetCompactedAddressReturnsCorrectString($value, $hex, $expanded, $compacted, $dot)
     {
         $ip = IP::factory($value);
         $this->assertSame($compacted, $ip->getCompactedAddress());
@@ -166,11 +182,13 @@ class MultiTest extends TestCase
      * @param string $value
      * @param string $hex
      * @param string $expanded
+     * @param string $compacted
+     * @param string $dot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(MultiDataProvider::class, 'getValidProtocolIpAddresses')]
-    public function testGetExpandedAddressReturnsCorrectString($value, $hex, $expanded)
+    public function testGetExpandedAddressReturnsCorrectString($value, $hex, $expanded, $compacted, $dot)
     {
         $ip = IP::factory($value);
         $this->assertSame($expanded, $ip->getExpandedAddress());
@@ -198,11 +216,15 @@ class MultiTest extends TestCase
      * @test
      * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getValidIpVersion6Addresses()
      * @param string $value
+     * @param string $hex
+     * @param string $expanded
+     * @param string $compacted
+     * @param string $dot
      * @return void
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(MultiDataProvider::class, 'getValidIpVersion6Addresses')]
-    public function testDotAddressThrowsExceptionForNonVersion4Addresses($value)
+    public function testDotAddressThrowsExceptionForNonVersion4Addresses($value, $hex, $expanded, $compacted, $dot)
     {
         $this->expectException(\Darsyn\IP\Exception\WrongVersionException::class);
         try {


### PR DESCRIPTION
Version 5.x of this library is compatible with PHP versions 5.6 to 8.3; update README and CI jobs to reflect this accurately.