### PR TITLE
IPv6: classify entire `fc00::/7` as private use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add code style ruleset definition via PHP-CS-Fixer configuration. Apply the
   code style to the entire codebase, and enable checking as another CI job in
   GitHub Actions.
+- Bugfix: classify full `fc00::/7` block as private use.
 
 ## `6.0.0`
 

--- a/src/Version/IPv6.php
+++ b/src/Version/IPv6.php
@@ -104,7 +104,10 @@ class IPv6 extends AbstractIP implements Version6Interface
 
     public function isPrivateUse(): bool
     {
-        return $this->inRange(new self(Binary::fromHex('fd000000000000000000000000000000')), 8);
+        // Check `fc00::/7` to cover both:
+        //  - `fd00::/8` (locally-assigned), and
+        //  - `fc00::/8` (reserved for centrally-assigned; proposed but never standardised, now undefined).
+        return $this->inRange(new self(Binary::fromHex('fc000000000000000000000000000000')), 7);
     }
 
     public function isUnspecified(): bool

--- a/tests/DataProvider/IPv6.php
+++ b/tests/DataProvider/IPv6.php
@@ -270,7 +270,7 @@ class IPv6 implements IpDataProviderInterface
             '::1' => self::LOOPBACK | self::UNICAST_OTHER | self::COMPATIBLE,
             '::0.0.0.2' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL | self::COMPATIBLE,
             '1::' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL,
-            'fc00::' => self::UNIQUE_LOCAL | self::UNICAST_OTHER,
+            'fc00::' => self::PRIVATE_USE | self::UNIQUE_LOCAL | self::UNICAST_OTHER,
             'fdff:ffff::' => self::PRIVATE_USE | self::UNIQUE_LOCAL | self::UNICAST_OTHER,
             'fe80:ffff::' => self::LINK_LOCAL,
             'fe80::' => self::LINK_LOCAL,


### PR DESCRIPTION
`isPrivateUse()` only matched the locally-assigned half (`fd00::/8`) of the Unique Local Address block, while `isUniqueLocal()` matched the full `fc00::/7`. Fix disparity between `isPrivateUse()` and `isUniqueLocal()` by widening to report the entire block as private, as per RFC 4193.