### PR TITLE
Rename `isPublicUse()` to `isGloballyReachable()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 - Bugfix: align `isPublicUse()`, `isUnicastGlobal()` and `isDocumentation()`
   with the IANA special-purpose address registries, and update RFC
   references/citations for all address classification methods.
+- Rename `isPublicUse()` to `isGloballyReachable()`, conforming to the official
+  wording used in the IANA special-purpose address registries ("Public Use"
+  does not appear in them). Keep `isPublicUse()` as a deprecated alias.
 
 ## `6.0.0`
 

--- a/docs/07-types.md
+++ b/docs/07-types.md
@@ -192,7 +192,7 @@ $ip = IP::factory('127.0.0.1');
 $ip->isDocumentation(); // bool(false)
 ```
 
-### Public Use (Global)
+### Globally Reachable
 
 Whether the IP appears to be publicly/globally routable (please refer to the
 following:
@@ -205,7 +205,7 @@ following:
 use Darsyn\IP\Version\Multi as IP;
 
 $ip = IP::factory('127.0.0.1');
-$ip->isPublicUse(); // bool(false)
+$ip->isGloballyReachable(); // bool(false)
 ```
 
 ## IPv4 Specific

--- a/docs/10-api.md
+++ b/docs/10-api.md
@@ -24,7 +24,7 @@
 | `isUnspecified()`                     | `bool`               | ✓    | ✓    | ✓     |
 | `isBenchmarking()`                    | `bool`               | ✓    | ✓    | ✓     |
 | `isDocumentation()`                   | `bool`               | ✓    | ✓    | ✓     |
-| `isPublicUse()`                       | `bool`               | ✓    | ✓    | ✓     |
+| `isGloballyReachable()`               | `bool`               | ✓    | ✓    | ✓     |
 | `isBroadcast()`                       | `bool`               | ✓    |      | ✓     |
 | `isShared()`                          | `bool`               | ✓    |      | ✓     |
 | `isFutureReserved()`                  | `bool`               | ✓    |      | ✓     |

--- a/src/IpInterface.php
+++ b/src/IpInterface.php
@@ -142,13 +142,21 @@ interface IpInterface
     public function isDocumentation(): bool;
 
     /**
+     * Superseded by `isGloballyReachable()` which conforms to official wording;
+     * "Public Use" does not appear in the IANA special-purpose registries.
+     *
+     * @deprecated Use isGloballyReachable() instead.
+     */
+    public function isPublicUse(): bool;
+
+    /**
      * Whether the IP appears to be publicly/globally routable. Please refer to
      * the IANA Special-Purpose Address Registry documents.
      *
      * @see https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
      * @see https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
      */
-    public function isPublicUse(): bool;
+    public function isGloballyReachable(): bool;
 
     /** Implement string casting for IP objects. */
     public function __toString(): string;

--- a/src/Version/IPv4.php
+++ b/src/Version/IPv4.php
@@ -106,7 +106,13 @@ class IPv4 extends AbstractIP implements Version4Interface
             || $this->inRange(new self(Binary::fromHex('e9fc0000')), 24);
     }
 
+    /** @deprecated Use isGloballyReachable() instead. */
     public function isPublicUse(): bool
+    {
+        return $this->isGloballyReachable();
+    }
+
+    public function isGloballyReachable(): bool
     {
         // The PCP anycast address `192.0.0.9` (RFC 7723) and the TURN anycast
         // address `192.0.0.10` (RFC 8155) are globally routable, despite being

--- a/src/Version/IPv6.php
+++ b/src/Version/IPv6.php
@@ -129,7 +129,13 @@ class IPv6 extends AbstractIP implements Version6Interface
             || $this->inRange(new self(Binary::fromHex('3fff0000000000000000000000000000')), 20);
     }
 
+    /** @deprecated Use isGloballyReachable() instead. */
     public function isPublicUse(): bool
+    {
+        return $this->isGloballyReachable();
+    }
+
+    public function isGloballyReachable(): bool
     {
         return self::MULTICAST_GLOBAL === $this->getMulticastScope() || $this->isUnicastGlobal();
     }

--- a/src/Version/Multi.php
+++ b/src/Version/Multi.php
@@ -234,11 +234,17 @@ class Multi extends IPv6 implements MultiVersionInterface
             : parent::isDocumentation();
     }
 
+    /** @deprecated Use isGloballyReachable() instead. */
     public function isPublicUse(): bool
     {
+        return $this->isGloballyReachable();
+    }
+
+    public function isGloballyReachable(): bool
+    {
         return $this->isEmbedded()
-            ? (new IPv4($this->getShortBinary()))->isPublicUse()
-            : parent::isPublicUse();
+            ? (new IPv4($this->getShortBinary()))->isGloballyReachable()
+            : parent::isGloballyReachable();
     }
 
     public function isUniqueLocal(): bool

--- a/tests/DataProvider/IPv4.php
+++ b/tests/DataProvider/IPv4.php
@@ -195,9 +195,9 @@ class IPv4 implements IpDataProviderInterface
     }
 
     /** @return list<array{string, bool}> */
-    public static function getPublicUseIpAddresses()
+    public static function getGloballyReachableIpAddresses()
     {
-        return self::getCategoryOfIpAddresses(self::PUBLIC_USE_V4);
+        return self::getCategoryOfIpAddresses(self::GLOBALLY_REACHABLE_V4);
     }
 
     /** @return list<array{string, bool}> */
@@ -226,19 +226,19 @@ class IPv4 implements IpDataProviderInterface
             '172.31.254.253' => self::PRIVATE_USE,
             '169.254.253.242' => self::LINK_LOCAL,
             '192.0.2.183' => self::DOCUMENTATION,
-            '192.1.2.183' => self::PUBLIC_USE,
+            '192.1.2.183' => self::GLOBALLY_REACHABLE_V4,
             '192.168.254.253' => self::PRIVATE_USE,
             '198.51.100.0' => self::DOCUMENTATION,
             '203.0.113.0' => self::DOCUMENTATION,
-            '203.2.113.0' => self::PUBLIC_USE,
-            '192.88.99.1' => self::PUBLIC_USE,
+            '203.2.113.0' => self::GLOBALLY_REACHABLE_V4,
+            '192.88.99.1' => self::GLOBALLY_REACHABLE_V4,
             '192.88.99.2' => 0,
             '233.252.0.1' => self::MULTICAST_IPV4 | self::DOCUMENTATION,
             '255.255.255.255' => self::BROADCAST,
             '198.18.0.0' => self::BENCHMARKING,
             '198.18.54.2' => self::BENCHMARKING,
-            '224.0.0.0' => self::PUBLIC_USE | self::MULTICAST_IPV4,
-            '239.255.255.255' => self::PUBLIC_USE | self::MULTICAST_IPV4,
+            '224.0.0.0' => self::GLOBALLY_REACHABLE_V4 | self::MULTICAST_IPV4,
+            '239.255.255.255' => self::GLOBALLY_REACHABLE_V4 | self::MULTICAST_IPV4,
             '0.0.0.0' => self::UNSPECIFIED,
             '10.0.0.0' => self::PRIVATE_USE,
             '10.255.255.255' => self::PRIVATE_USE,
@@ -252,16 +252,16 @@ class IPv4 implements IpDataProviderInterface
             '169.254.255.255' => self::LINK_LOCAL,
             '100.64.91.200' => self::SHARED,
             '251.0.12.101' => self::FUTURE_RESERVED,
-            '192.18.0.0' => self::PUBLIC_USE,
+            '192.18.0.0' => self::GLOBALLY_REACHABLE_V4,
             '198.19.255.255' => self::BENCHMARKING,
-            '129.129.154.203' => self::PUBLIC_USE,
-            '239.248.153.114' => self::PUBLIC_USE | self::MULTICAST_IPV4,
-            '85.101.159.135' => self::PUBLIC_USE,
-            '72.64.156.77' => self::PUBLIC_USE,
-            '162.199.210.167' => self::PUBLIC_USE,
-            '2.12.191.95' => self::PUBLIC_USE,
-            '83.125.176.74' => self::PUBLIC_USE,
-            '224.0.65.129' => self::PUBLIC_USE | self::MULTICAST_IPV4,
+            '129.129.154.203' => self::GLOBALLY_REACHABLE_V4,
+            '239.248.153.114' => self::GLOBALLY_REACHABLE_V4 | self::MULTICAST_IPV4,
+            '85.101.159.135' => self::GLOBALLY_REACHABLE_V4,
+            '72.64.156.77' => self::GLOBALLY_REACHABLE_V4,
+            '162.199.210.167' => self::GLOBALLY_REACHABLE_V4,
+            '2.12.191.95' => self::GLOBALLY_REACHABLE_V4,
+            '83.125.176.74' => self::GLOBALLY_REACHABLE_V4,
+            '224.0.65.129' => self::GLOBALLY_REACHABLE_V4 | self::MULTICAST_IPV4,
         ];
     }
 

--- a/tests/DataProvider/IPv6.php
+++ b/tests/DataProvider/IPv6.php
@@ -212,18 +212,18 @@ class IPv6 implements IpDataProviderInterface
     }
 
     /** @return list<array{string, bool}> */
-    public static function getPublicUseIpAddresses()
+    public static function getGloballyReachableIpAddresses()
     {
-        return self::getCategoryOfIpAddresses(self::PUBLIC_USE_V6);
+        return self::getCategoryOfIpAddresses(self::GLOBALLY_REACHABLE_V6);
     }
 
     /** @return list<array{string, bool}> */
-    public static function getPublicUseIpAddressesExcludingMapped()
+    public static function getGloballyReachableIpAddressesExcludingMapped()
     {
         // Exclude IPv4-embedded addresses embedded using the Mapped strategy,
         // they may fail the test because the IPv4 equivalent is not public (eg,
         // "::ffff:7f00:1").
-        return self::getCategoryOfIpAddresses(self::PUBLIC_USE_V6, self::MAPPED);
+        return self::getCategoryOfIpAddresses(self::GLOBALLY_REACHABLE_V6, self::MAPPED);
     }
 
     /** @return list<array{string, bool}> */
@@ -268,8 +268,8 @@ class IPv6 implements IpDataProviderInterface
             '::' => self::UNSPECIFIED | self::UNICAST_OTHER | self::COMPATIBLE,
             '::0' => self::UNSPECIFIED | self::UNICAST_OTHER | self::COMPATIBLE,
             '::1' => self::LOOPBACK | self::UNICAST_OTHER | self::COMPATIBLE,
-            '::0.0.0.2' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL | self::COMPATIBLE,
-            '1::' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL,
+            '::0.0.0.2' => self::GLOBALLY_REACHABLE_V6 | self::UNICAST_GLOBAL | self::COMPATIBLE,
+            '1::' => self::GLOBALLY_REACHABLE_V6 | self::UNICAST_GLOBAL,
             'fc00::' => self::PRIVATE_USE | self::UNIQUE_LOCAL | self::UNICAST_OTHER,
             'fdff:ffff::' => self::PRIVATE_USE | self::UNIQUE_LOCAL | self::UNICAST_OTHER,
             'fe80:ffff::' => self::LINK_LOCAL,
@@ -279,24 +279,24 @@ class IPv6 implements IpDataProviderInterface
             'febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff' => self::LINK_LOCAL,
             'fe80::ffff:ffff:ffff:ffff' => self::LINK_LOCAL,
             'fe80:0:0:1::' => self::LINK_LOCAL,
-            'fec0::' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL,
+            'fec0::' => self::GLOBALLY_REACHABLE_V6 | self::UNICAST_GLOBAL,
             'ff01::' => self::MULTICAST_INTERFACE_LOCAL,
             'ff02::' => self::MULTICAST_LINK_LOCAL,
             'ff03::' => self::MULTICAST_REALM_LOCAL,
             'ff04::' => self::MULTICAST_ADMIN_LOCAL,
             'ff05::' => self::MULTICAST_SITE_LOCAL,
             'ff08::' => self::MULTICAST_ORGANIZATION_LOCAL,
-            'ff0e::' => self::PUBLIC_USE_V6 | self::MULTICAST_GLOBAL,
+            'ff0e::' => self::GLOBALLY_REACHABLE_V6 | self::MULTICAST_GLOBAL,
             '2001:db8:85a3::8a2e:370:7334' => self::DOCUMENTATION | self::UNICAST_OTHER,
             '2001:2::ac32:23ff:21' => self::BENCHMARKING | self::UNICAST_OTHER,
-            '2001:1::1' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL,
+            '2001:1::1' => self::GLOBALLY_REACHABLE_V6 | self::UNICAST_GLOBAL,
             '2001:10::' => self::UNICAST_OTHER,
             '3fff::1' => self::DOCUMENTATION | self::UNICAST_OTHER,
             '64:ff9b:1::1' => self::UNICAST_OTHER,
             '100::1' => self::UNICAST_OTHER,
             '100:0:0:1::1' => self::UNICAST_OTHER,
             '5f00::1' => self::UNICAST_OTHER,
-            '102:304:506:708:90a:b0c:d0e:f10' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL,
+            '102:304:506:708:90a:b0c:d0e:f10' => self::GLOBALLY_REACHABLE_V6 | self::UNICAST_GLOBAL,
             'fd00::' => self::PRIVATE_USE | self::UNIQUE_LOCAL | self::UNICAST_OTHER,
             'fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff' => self::PRIVATE_USE | self::UNIQUE_LOCAL | self::UNICAST_OTHER,
             'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff' => self::MULTICAST_OTHER,
@@ -308,17 +308,17 @@ class IPv6 implements IpDataProviderInterface
             '2002:7f00:1::' => self::UNICAST_OTHER | self::DERIVED | self::LOOPBACK_DERIVED,
             '2002:7f00:1:1::1' => self::UNICAST_OTHER | self::DERIVED | self::LOOPBACK_DERIVED,
             '2002:1234:4321:0:00:000:0000::' => self::UNICAST_OTHER | self::DERIVED,
-            '::7f00:1' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL | self::COMPATIBLE | self::LOOPBACK_COMPATIBLE,
-            '::12.34.56.78' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL | self::COMPATIBLE,
-            '0::000:0000:b12:cab' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL | self::COMPATIBLE,
-            '1cc9:7d7f:2a9f:cabd:9186:2be5:bef1:6a54' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL,
-            'b638:cc70:716:c4d4:f69c:4ee3:6c65:a0b2' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL,
-            '140c:12f1:6e6f:c0bb:980e:3816:3e52:1193' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL,
-            '7a30:bf4:4c6c:8dc1:e340:774d:6487:3822' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL,
-            '6af8:1ceb:eaae:104a:829c:e76e:5802:13f8' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL,
-            '3e48:c9fd:c569:f5dd:ee36:8075:691b:8234' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL,
-            'cab2:4f27:790f:cf03:5241:9eff:aba5:bb5c' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL,
-            'e896:8866:872b:bd4f:6d60:7aa8:ebe5:36f1' => self::PUBLIC_USE_V6 | self::UNICAST_GLOBAL,
+            '::7f00:1' => self::GLOBALLY_REACHABLE_V6 | self::UNICAST_GLOBAL | self::COMPATIBLE | self::LOOPBACK_COMPATIBLE,
+            '::12.34.56.78' => self::GLOBALLY_REACHABLE_V6 | self::UNICAST_GLOBAL | self::COMPATIBLE,
+            '0::000:0000:b12:cab' => self::GLOBALLY_REACHABLE_V6 | self::UNICAST_GLOBAL | self::COMPATIBLE,
+            '1cc9:7d7f:2a9f:cabd:9186:2be5:bef1:6a54' => self::GLOBALLY_REACHABLE_V6 | self::UNICAST_GLOBAL,
+            'b638:cc70:716:c4d4:f69c:4ee3:6c65:a0b2' => self::GLOBALLY_REACHABLE_V6 | self::UNICAST_GLOBAL,
+            '140c:12f1:6e6f:c0bb:980e:3816:3e52:1193' => self::GLOBALLY_REACHABLE_V6 | self::UNICAST_GLOBAL,
+            '7a30:bf4:4c6c:8dc1:e340:774d:6487:3822' => self::GLOBALLY_REACHABLE_V6 | self::UNICAST_GLOBAL,
+            '6af8:1ceb:eaae:104a:829c:e76e:5802:13f8' => self::GLOBALLY_REACHABLE_V6 | self::UNICAST_GLOBAL,
+            '3e48:c9fd:c569:f5dd:ee36:8075:691b:8234' => self::GLOBALLY_REACHABLE_V6 | self::UNICAST_GLOBAL,
+            'cab2:4f27:790f:cf03:5241:9eff:aba5:bb5c' => self::GLOBALLY_REACHABLE_V6 | self::UNICAST_GLOBAL,
+            'e896:8866:872b:bd4f:6d60:7aa8:ebe5:36f1' => self::GLOBALLY_REACHABLE_V6 | self::UNICAST_GLOBAL,
         ];
     }
 

--- a/tests/DataProvider/IpDataProviderInterface.php
+++ b/tests/DataProvider/IpDataProviderInterface.php
@@ -16,13 +16,13 @@ interface IpDataProviderInterface
     public const MULTICAST_IPV4 = 1 << 6;
 
     // IPv4
-    public const PUBLIC_USE_V4 = 1 << 7;
+    public const GLOBALLY_REACHABLE_V4 = 1 << 7;
     public const BROADCAST = 1 << 8;
     public const SHARED = 1 << 9;
     public const FUTURE_RESERVED = 1 << 10;
 
     // IPv6
-    public const PUBLIC_USE_V6 = 1 << 11;
+    public const GLOBALLY_REACHABLE_V6 = 1 << 11;
     public const MULTICAST_INTERFACE_LOCAL = 1 << 12;
     public const MULTICAST_LINK_LOCAL = 1 << 13;
     public const MULTICAST_REALM_LOCAL = 1 << 14;
@@ -42,9 +42,9 @@ interface IpDataProviderInterface
     public const LOOPBACK_DERIVED = 1 << 28;
 
     // Combinations
-    public const PUBLIC_USE = 0
-        | self::PUBLIC_USE_V4
-        | self::PUBLIC_USE_V6;
+    public const GLOBALLY_REACHABLE = 0
+        | self::GLOBALLY_REACHABLE_V4
+        | self::GLOBALLY_REACHABLE_V6;
     public const LOOPBACK_EMBEDDED = 0
         | self::LOOPBACK_MAPPED
         | self::LOOPBACK_COMPATIBLE

--- a/tests/DataProvider/Multi.php
+++ b/tests/DataProvider/Multi.php
@@ -270,9 +270,9 @@ class Multi
     }
 
     /** @return list<array{string, bool}> */
-    public static function getPublicUseIpAddresses()
+    public static function getGloballyReachableIpAddresses()
     {
-        return array_merge(IPv4::getPublicUseIpAddresses(), IPv6::getPublicUseIpAddressesExcludingMapped());
+        return array_merge(IPv4::getGloballyReachableIpAddresses(), IPv6::getGloballyReachableIpAddressesExcludingMapped());
     }
 
     /** @return list<array{string, bool, bool}> */

--- a/tests/Version/IPv4Test.php
+++ b/tests/Version/IPv4Test.php
@@ -415,14 +415,14 @@ class IPv4Test extends TestCase
 
     /**
      * @test
-     * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getPublicUseIpAddresses()
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getGloballyReachableIpAddresses()
      */
     #[PHPUnit\Test]
-    #[PHPUnit\DataProviderExternal(IPv4DataProvider::class, 'getPublicUseIpAddresses')]
-    public function testIsPublicUse(string $value, bool $isPublicUse): void
+    #[PHPUnit\DataProviderExternal(IPv4DataProvider::class, 'getGloballyReachableIpAddresses')]
+    public function testIsGloballyReachable(string $value, bool $isGloballyReachable): void
     {
         $ip = IP::factory($value);
-        $this->assertSame($isPublicUse, $ip->isPublicUse());
+        $this->assertSame($isGloballyReachable, $ip->isGloballyReachable());
     }
 
     /**

--- a/tests/Version/IPv6Test.php
+++ b/tests/Version/IPv6Test.php
@@ -457,14 +457,14 @@ class IPv6Test extends TestCase
 
     /**
      * @test
-     * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getPublicUseIpAddresses()
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getGloballyReachableIpAddresses()
      */
     #[PHPUnit\Test]
-    #[PHPUnit\DataProviderExternal(IPv6DataProvider::class, 'getPublicUseIpAddresses')]
-    public function testIsPublicUse(string $value, bool $isPublicUse): void
+    #[PHPUnit\DataProviderExternal(IPv6DataProvider::class, 'getGloballyReachableIpAddresses')]
+    public function testIsGloballyReachable(string $value, bool $isGloballyReachable): void
     {
         $ip = IP::factory($value);
-        $this->assertSame($isPublicUse, $ip->isPublicUse());
+        $this->assertSame($isGloballyReachable, $ip->isGloballyReachable());
     }
 
     /**

--- a/tests/Version/MultiTest.php
+++ b/tests/Version/MultiTest.php
@@ -390,14 +390,14 @@ class MultiTest extends TestCase
 
     /**
      * @test
-     * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getPublicUseIpAddresses()
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getGloballyReachableIpAddresses()
      */
     #[PHPUnit\Test]
-    #[PHPUnit\DataProviderExternal(MultiDataProvider::class, 'getPublicUseIpAddresses')]
-    public function testIsPublicUse(string $value, bool $isPublicUse): void
+    #[PHPUnit\DataProviderExternal(MultiDataProvider::class, 'getGloballyReachableIpAddresses')]
+    public function testIsGloballyReachable(string $value, bool $isGloballyReachable): void
     {
         $ip = IP::factory($value, new Strategy\Mapped());
-        $this->assertSame($isPublicUse, $ip->isPublicUse());
+        $this->assertSame($isGloballyReachable, $ip->isGloballyReachable());
     }
 
     /**


### PR DESCRIPTION
Conform to official wording from the IANA special-purpose address registries; _Public Use_ does not appear in them. Keep `isPublicUse()` as a deprecated alias.