### PR TITLE
Add NAT64 (RFC 6052) embedding strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 - Rename `isPublicUse()` to `isGloballyReachable()`, conforming to the official
   wording used in the IANA special-purpose address registries ("Public Use"
   does not appear in them). Keep `isPublicUse()` as a deprecated alias.
+- Add NAT64 (RFC 6052 § 2.2) embedding strategy, with named constructors for
+  the Well-known Prefix (`64:ff9b::/96`), operator Network-specific Prefixes,
+  and the RFC 8215 Local-use prefix (`64:ff9b:1::/48`).
 
 ## `6.0.0`
 

--- a/docs/05-strategies.md
+++ b/docs/05-strategies.md
@@ -1,18 +1,22 @@
 # Embedding Strategies
 
-When using version 4 and version 6 addresses interchangeably (via the 
+When using version 4 and version 6 addresses interchangeably (via the
 `Multi` class), version 4 addresses are *embedded* into version 6 addresses so
 that both versions are stored as 16-byte binary sequences.
 
 Unfortunately there are several different strategies for embedding a version 4
 address into version 6, so this library offers various strategy implementations
-for the main three: 
+for the main four:
+
+> In the formats below, `X` marks the embedded version 4 address, and `?` marks
+> bits that play no part in detection/extraction.
 
 | Strategy Name   | Implementation                  | Format                                    |
 |-----------------|---------------------------------|-------------------------------------------|
 | 6to4-derived    | `Darsyn\IP\Strategy\Derived`    | `2002:XXXX:XXXX:????:????:????:????:????` |
 | IPv4-compatible | `Darsyn\IP\Strategy\Compatible` | `0000:0000:0000:0000:0000:0000:XXXX:XXXX` |
 | IPv4-mapped     | `Darsyn\IP\Strategy\Mapped`     | `0000:0000:0000:0000:0000:ffff:XXXX:XXXX` |
+| NAT64           | `Darsyn\IP\Strategy\Nat64`      | (see below)                               |
 
 Each embedding strategy implements the
 `Darsyn\IP\Strategy\EmbeddingStrategyInterface` which defines methods to:
@@ -40,3 +44,48 @@ IP::setDefaultEmbeddingStrategy(new Strategy\Compatible);
 // But for this specific instance use the 6to4-derived embedding strategy.
 $ip = IP::factory('127.0.0.1', new Strategy\Derived);
 ```
+
+## NAT64 (RFC 6052)
+Unlike the other strategies, `Nat64` has no public constructor — it is
+instantiated via named constructors only:
+- `Nat64::wellKnown()` embeds at the Well-known Prefix `64:ff9b::/96`
+  (RFC 6052 § 2.1). Note that RFC 6052 § 3.1 forbids embedding non-global
+  version 4 addresses within the Well-known Prefix; this library deliberately
+  does not enforce that restriction.
+- `Nat64::localUse()` embeds at the local-use prefix `64:ff9b:1::/48` (RFC
+  8215), applying RFC 6052 § 2.2 `/48` positioning; RFC 8215 defines only the
+  prefix, not an embedding layout. Narrower local-use prefixes can be
+  constructed through `networkSpecific()`.
+- `Nat64::networkSpecific(IPv6 $prefix, int $length)` embeds at a
+  Network-Specific Prefix from an operator's own unicast space. The length
+  must be one of `Nat64::PREFIX_LENGTHS` (32, 40, 48, 56, 64, or 96 bits, as
+  permitted by RFC 6052 § 2.2). Any bits set after that length will be zeroed.
+
+### Well-known Prefix
+
+| Strategy Name      | Format                                    |
+|--------------------|-------------------------------------------|
+| NAT64 (Well-known) | `0064:ff9b:0000:0000:0000:0000:XXXX:XXXX` |
+
+### Local-use Prefix
+The embedded IPv4 address uses the RFC 6052 § 2.2 `/48` layout; RFC 8215 defines
+only the prefix.
+
+| Strategy Name     | Format                                    |
+|-------------------|-------------------------------------------|
+| NAT64 (Local-use) | `0064:ff9b:0001:XXXX:??XX:XX??:????:????` |
+
+### Network-specific Prefix
+The position of the embedded IPv4 address depends on the prefix length (RFC 6052
+§ 2.2).
+
+> In the formats below, `P` marks the configured prefix
+
+| CIDR Length | Format                                    |
+|-------------|-------------------------------------------|
+| `/32`       | `PPPP:PPPP:XXXX:XXXX:????:????:????:????` |
+| `/40`       | `PPPP:PPPP:PPXX:XXXX:??XX:????:????:????` |
+| `/48`       | `PPPP:PPPP:PPPP:XXXX:??XX:XX??:????:????` |
+| `/56`       | `PPPP:PPPP:PPPP:PPXX:??XX:XXXX:????:????` |
+| `/64`       | `PPPP:PPPP:PPPP:PPPP:??XX:XXXX:XX??:????` |
+| `/96`       | `PPPP:PPPP:PPPP:PPPP:PPPP:PPPP:XXXX:XXXX` |

--- a/src/Strategy/Nat64.php
+++ b/src/Strategy/Nat64.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Darsyn\IP\Strategy;
+
+use Darsyn\IP\Exception\Strategy as StrategyException;
+use Darsyn\IP\Util\Binary;
+use Darsyn\IP\Util\MbString;
+use Darsyn\IP\Version\IPv6;
+
+/**
+ * Embeds an IPv4 address within an IPv4-embedded IPv6 prefix, as defined by
+ * RFC 6052 ("IPv6 Addressing of IPv4/IPv6 Translators"), § 2.2.
+ *
+ * Instances are created through named constructors only: `wellKnown()` for the
+ * "Well-Known Prefix" `64:ff9b::/96` (§ 2.1); `networkSpecific()` for a
+ * Network-Specific Prefix from an operator's own unicast space, using any of
+ * the six prefix lengths permitted by § 2.2 (32, 40, 48, 56, 64, or 96 bits);
+ * and `localUse()` for the local-use prefix `64:ff9b:1::/48` (RFC 8215). For
+ * every prefix length except 96 the embedded IPv4 address is interrupted by
+ * the reserved octet (bits 64 to 71), which must always be zero.
+ *
+ * Note: `isEmbedded()` detects any address within the configured prefix;
+ * receivers decide whether an address embeds an IPv4 address by prefix
+ * membership alone (RFC 6146 § 3.5). The canonical address has the reserved
+ * octet and the suffix bits zeroed, whereas non-canonical addresses carry
+ * other values in them: RFC 6052 § 2.2 says translators should ignore
+ * non-zero suffix bits, and the extraction algorithm (§ 2.3) never inspects
+ * the reserved octet.
+ *
+ * Consequently, version-aware operations on Multi-type IPs treat every
+ * address under the configured prefix as an embedded IPv4 address, even
+ * though only the canonical form can round-trip through extraction.
+ *
+ * The Well-Known Prefix is globally reachable, but not reserved by protocol.
+ * RFC 6052 § 3.1 states that non-global IPv4 addresses must NOT be embedded
+ * within the Well-Known Prefix; the restriction does not apply to
+ * Network-Specific Prefixes. This library deliberately does not enforce it.
+ */
+class Nat64 implements EmbeddingStrategyInterface
+{
+    /** Hex representation of the Well-Known Prefix `64:ff9b::/96` (RFC 6052 § 2.1). */
+    public const WELL_KNOWN_PREFIX = '0064ff9b000000000000000000000000';
+
+    /** Hex representation of the local-use prefix `64:ff9b:1::/48` (RFC 8215). */
+    public const LOCAL_USE_PREFIX = '0064ff9b000100000000000000000000';
+
+    /** Prefix lengths permitted by RFC 6052 § 2.2. */
+    public const PREFIX_LENGTHS = [32, 40, 48, 56, 64, 96];
+
+    /** @var string $prefix */
+    private $prefix;
+
+    /** @var int $length */
+    private $length;
+
+    private function __construct(string $prefix, int $length)
+    {
+        if (16 !== $bytes = MbString::getLength($prefix)) {
+            throw new \InvalidArgumentException(sprintf(
+                'NAT64 embedding strategy requires an IPv6 binary (16 bytes) as prefix; got %d bytes.',
+                $bytes
+            ));
+        }
+        $this->prefix = $prefix;
+        $this->length = $length;
+    }
+
+    /**
+     * Named constructor for the Well-Known Prefix `64:ff9b::/96`
+     * (RFC 6052 § 2.1).
+     */
+    public static function wellKnown(): self
+    {
+        return new self(Binary::fromHex(self::WELL_KNOWN_PREFIX), 96);
+    }
+
+    /**
+     * Named constructor for a Network-Specific Prefix from an operator's own
+     * unicast space, eg `Nat64::networkSpecific(IPv6::factory('2001:db8:122:344::'), 64)`.
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function networkSpecific(IPv6 $prefix, int $length): self
+    {
+        if (!\in_array($length, self::PREFIX_LENGTHS, true)) {
+            throw new \InvalidArgumentException(\sprintf(
+                'NAT64 prefixes must be 32, 40, 48, 56, 64, or 96 bits long (RFC 6052 § 2.2); got %d.',
+                $length
+            ));
+        }
+        // Calculate the network address. However, $prefix could be any class that extends IPv6 (including
+        // Multi, which would then use its own embedding strategy when calculating the network address).
+        // Don't use `IPv6::factory()->getNetworkIp()` because:
+        // (a) it's unnecessary computation, checking both binary and ASCII formats, and
+        // (b) could accidentally read a 16-byte binary sequence as a
+        //     `[a-z0-9:]{16}` ASCII address.
+        $prefix = MbString::padString(MbString::subString($prefix->getBinary(), 0, \intdiv($length, 8)), 16, "\0");
+        return new self($prefix, $length);
+    }
+
+    /**
+     * Named constructor for the local-use prefix `64:ff9b:1::/48` (RFC 8215),
+     * applying RFC 6052 § 2.2 /48 positioning (RFC 8215 defines only the
+     * prefix, not an embedding layout); narrower local-use prefixes go through
+     * `networkSpecific()`.
+     */
+    public static function localUse(): self
+    {
+        return new self(Binary::fromHex(self::LOCAL_USE_PREFIX), 48);
+    }
+
+    /**
+     * The network address of the configured prefix as a 16-byte binary
+     * sequence; bits beyond getPrefixLength() are always zero.
+     */
+    public function getPrefix(): string
+    {
+        return $this->prefix;
+    }
+
+    public function getPrefixLength(): int
+    {
+        return $this->length;
+    }
+
+    public function isEmbedded(string $binary): bool
+    {
+        // Receivers decide whether an address embeds an IPv4 address by
+        // prefix membership alone (RFC 6146 § 3.5); the values of the
+        // reserved octet and the suffix do not affect detection.
+        $bytes = \intdiv($this->length, 8);
+        return 16 === MbString::getLength($binary)
+            && MbString::subString($this->prefix, 0, $bytes) === MbString::subString($binary, 0, $bytes);
+    }
+
+    /**
+     * Warning: extraction is positional (RFC 6052 § 2.3) and does not verify
+     * that the address lies within the configured prefix, nor that the
+     * reserved octet (bits 64 to 71) and the suffix are zero; when the suffix
+     * bits are not zero, RFC 6052 § 2.2 says translators should ignore them
+     * and proceed as if they were zero.
+     */
+    public function extract(string $binary): string
+    {
+        if (16 !== MbString::getLength($binary)) {
+            throw new StrategyException\ExtractionException($binary, $this);
+        }
+        $bytes = \intdiv($this->length, 8);
+        if (96 === $this->length) {
+            return MbString::subString($binary, $bytes, 4);
+        }
+        // The reserved octet (bits 64 to 71) interrupts the embedded IPv4
+        // address for every prefix length other than 96; stitch the address
+        // back together from either side of it.
+        $split = 8 - $bytes;
+        return MbString::subString($binary, $bytes, $split)
+            . MbString::subString($binary, 9, 4 - $split);
+    }
+
+    /**
+     * Warning: packing is not the inverse of extraction for every address
+     * that `isEmbedded()` accepts. Extraction keeps only the embedded IPv4
+     * address; the reserved octet (bits 64 to 71) and the suffix are
+     * zero-filled, so a direct pass-through (extract-pack) of a non-canonical
+     * address reconstructs the canonical form, not the original.
+     */
+    public function pack(string $binary): string
+    {
+        // Note: non-global IPv4 addresses should not be packed into the
+        // Well-Known Prefix (the restriction does not apply to
+        // Network-Specific Prefixes), but is not enforced here. It is down to
+        // the user of this library to know when to use which embedding
+        // strategy.
+        if (4 !== MbString::getLength($binary)) {
+            throw new StrategyException\PackingException($binary, $this);
+        }
+        $bytes = \intdiv($this->length, 8);
+        $prefix = MbString::subString($this->prefix, 0, $bytes);
+        if (96 === $this->length) {
+            return $prefix . $binary;
+        }
+        // The reserved octet (bits 64 to 71) must be zero (RFC 6052 § 2.2),
+        // and the suffix should be zero; zero-fill both.
+        $split = 8 - $bytes;
+        $withoutSuffix = $prefix
+            . MbString::subString($binary, 0, $split)
+            . "\0"
+            . MbString::subString($binary, $split);
+        return MbString::padString($withoutSuffix, 16, "\0");
+    }
+}

--- a/tests/DataProvider/Strategy/Nat64.php
+++ b/tests/DataProvider/Strategy/Nat64.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Darsyn\IP\Tests\DataProvider\Strategy;
+
+class Nat64
+{
+    /** @return list<array{string, bool}> */
+    public static function getValidIpAddresses()
+    {
+        $valid = array_map(static function (array $row) {
+            $row[1] = true;
+            return $row;
+        }, self::getValidSequences());
+        $invalid = array_map(static function (array $row) {
+            $row[1] = false;
+            return $row;
+        }, self::getInvalidSequences());
+        return array_merge($valid, $invalid);
+    }
+
+    /** @return list<array{string}> */
+    public static function getInvalidIpAddresses()
+    {
+        return [
+            [pack('H*', '20010db8000000000a608a2e037073')],
+            [pack('H*', '20010db8000000000a608a2e0370734556')],
+            ['12345678901234567'],
+            ['123456789012345'],
+        ];
+    }
+
+    /** @return list<array{string, string}> */
+    public static function getValidSequences()
+    {
+        return [
+            [pack('H*', '0064ff9b000000000000000000010000'), pack('H*', '00010000')],
+            [pack('H*', '0064ff9b00000000000000007f000001'), pack('H*', '7f000001')],
+            [pack('H*', '0064ff9b000000000000000012345678'), pack('H*', '12345678')],
+            [pack('H*', '0064ff9b00000000000000007f00a001'), pack('H*', '7f00a001')],
+        ];
+    }
+
+    /** @return list<array{string}> */
+    public static function getInvalidSequences()
+    {
+        return [
+            [pack('H*', '000000000000000000000fff00010000')],
+            [pack('H*', '00010000000000000000ffff0b120cab')],
+            [pack('H*', '0064ff9c00000000000000007f000001')],
+            [pack('H*', '00000000000000000000ffff7f00a001')],
+            [pack('H*', '20010db8000000000a608a2e03707334')],
+            // A Network-Specific Prefix embedding is not recognised by the
+            // default Well-Known Prefix strategy.
+            [pack('H*', '20010db80122034400000000c0000221')],
+        ];
+    }
+
+    /**
+     * RFC 6052 § 2.4 (Table 1): the IPv4 address 192.0.2.33 embedded within
+     * the documentation prefix 2001:db8::/32 at every permitted prefix length.
+     *
+     * @return list<array{string, int, string, string}>
+     */
+    public static function getNetworkSpecificSequences()
+    {
+        return [
+            // [ prefix address, prefix length, IPv6 binary, IPv4 binary ].
+            ['2001:db8::',         32, pack('H*', '20010db8c00002210000000000000000'), pack('H*', 'c0000221')],
+            ['2001:db8:100::',     40, pack('H*', '20010db801c000020021000000000000'), pack('H*', 'c0000221')],
+            ['2001:db8:122::',     48, pack('H*', '20010db80122c0000002210000000000'), pack('H*', 'c0000221')],
+            ['2001:db8:122:300::', 56, pack('H*', '20010db8012203c00000022100000000'), pack('H*', 'c0000221')],
+            ['2001:db8:122:344::', 64, pack('H*', '20010db80122034400c0000221000000'), pack('H*', 'c0000221')],
+            ['2001:db8:122:344::', 96, pack('H*', '20010db80122034400000000c0000221'), pack('H*', 'c0000221')],
+        ];
+    }
+
+    /** @return list<array{string, int, string}> */
+    public static function getNonMatchingNetworkSpecificSequences()
+    {
+        return [
+            // The prefix does not match.
+            ['2001:db8:122:344::', 96, pack('H*', '0064ff9b00000000000000007f000001')],
+            ['2001:db8:122::',     48, pack('H*', '20010db80123c0000002210000000000')],
+        ];
+    }
+
+    /**
+     * Non-canonical addresses within a Network-Specific Prefix: detection is
+     * by prefix membership alone (RFC 6146 § 3.5), so these are embedded, but
+     * a direct pass-through (extract-pack) reconstructs the canonical form,
+     * not the original.
+     *
+     * @return list<array{string, int, string, string, string}>
+     */
+    public static function getNonCanonicalNetworkSpecificSequences()
+    {
+        return [
+            // [ prefix address, prefix length, non-canonical IPv6 binary, IPv4 binary, canonical IPv6 binary ].
+            // The reserved octet (bits 64 to 71) is non-zero.
+            ['2001:db8::',         32, pack('H*', '20010db8c0000221ff00000000000000'), pack('H*', 'c0000221'), pack('H*', '20010db8c00002210000000000000000')],
+            ['2001:db8:100::',     40, pack('H*', '20010db801c000020121000000000000'), pack('H*', 'c0000221'), pack('H*', '20010db801c000020021000000000000')],
+            ['2001:db8:122::',     48, pack('H*', '20010db80122c0000102210000000000'), pack('H*', 'c0000221'), pack('H*', '20010db80122c0000002210000000000')],
+            ['2001:db8:122:300::', 56, pack('H*', '20010db8012203c00100022100000000'), pack('H*', 'c0000221'), pack('H*', '20010db8012203c00000022100000000')],
+            ['2001:db8:122:344::', 64, pack('H*', '20010db80122034401c0000221000000'), pack('H*', 'c0000221'), pack('H*', '20010db80122034400c0000221000000')],
+            // The suffix is non-zero.
+            ['2001:db8::',         32, pack('H*', '20010db8c00002210000000000000001'), pack('H*', 'c0000221'), pack('H*', '20010db8c00002210000000000000000')],
+            ['2001:db8:122:344::', 64, pack('H*', '20010db80122034400c0000221000001'), pack('H*', 'c0000221'), pack('H*', '20010db80122034400c0000221000000')],
+        ];
+    }
+
+    /** @return list<array{string, int, string}> */
+    public static function getValidNetworkSpecificArguments()
+    {
+        return [
+            // [ prefix address, prefix length, expected prefix hex ].
+            ['64:ff9b::',          96, '0064ff9b000000000000000000000000'],   // WKP expressed as an NSP.
+            ['64:ff9b:1::',        96, '0064ff9b000100000000000000000000'],   // Narrower local-use prefix as an NSP.
+            ['2001:db8::',         32, '20010db8000000000000000000000000'],
+            ['2001:db8:100::',     40, '20010db8010000000000000000000000'],
+            ['2001:db8:122::',     48, '20010db8012200000000000000000000'],
+            ['2001:db8:122:300::', 56, '20010db8012203000000000000000000'],
+            ['2001:db8:122:344::', 64, '20010db8012203440000000000000000'],
+            ['2001:db8:122:344::', 96, '20010db8012203440000000000000000'],
+        ];
+    }
+
+    /** @return list<array{string, int}> */
+    public static function getInvalidNetworkSpecificArguments()
+    {
+        return [
+            // Prefix lengths not permitted by RFC 6052 § 2.2.
+            ['2001:db8::', 0],
+            ['2001:db8::', 8],
+            ['2001:db8::', 24],
+            ['2001:db8::', 50],
+            ['2001:db8::', 95],
+            ['2001:db8::', 128],
+        ];
+    }
+
+    /**
+     * Prefix addresses with bits set after the prefix length, which
+     * `networkSpecific()` silently zeroes rather than rejecting.
+     *
+     * @return list<array{string, int, string}>
+     */
+    public static function getZeroedNetworkSpecificArguments()
+    {
+        return [
+            // [ prefix address, prefix length, expected prefix hex ].
+            ['2001:db8:1::',                32, '20010db8000000000000000000000000'],
+            ['2001:db8:1ff::',              40, '20010db8010000000000000000000000'],
+            ['2001:db8:122:ff00::',         48, '20010db8012200000000000000000000'],
+            ['2001:db8:122:344::',          56, '20010db8012203000000000000000000'],
+            ['2001:db8:122:344:c000:221::', 64, '20010db8012203440000000000000000'],
+            ['2001:db8::1',                 96, '20010db8000000000000000000000000'],
+        ];
+    }
+
+    /** @return list<array{string, string}> */
+    public static function getLocalUseSequences()
+    {
+        return [
+            // 192.0.2.33 → 64:ff9b:1:c000:2:2100::
+            [pack('H*', '0064ff9b0001c0000002210000000000'), pack('H*', 'c0000221')],
+            // 127.0.0.1 → 64:ff9b:1:7f00:0:100::
+            [pack('H*', '0064ff9b00017f000000010000000000'), pack('H*', '7f000001')],
+        ];
+    }
+
+    /** @return list<array{string}> */
+    public static function getNonMatchingLocalUseSequences()
+    {
+        return [
+            // A Well-Known Prefix address, not within 64:ff9b:1::/48.
+            [pack('H*', '0064ff9b00000000000000007f000001')],
+        ];
+    }
+
+    /**
+     * Non-canonical addresses within the local-use prefix `64:ff9b:1::/48`:
+     * detection is by prefix membership alone (RFC 6146 § 3.5), so these are
+     * embedded, but a direct pass-through (extract-pack) reconstructs the
+     * canonical form, not the original.
+     *
+     * @return list<array{string, string, string}>
+     */
+    public static function getNonCanonicalLocalUseSequences()
+    {
+        return [
+            // [ non-canonical IPv6 binary, IPv4 binary, canonical IPv6 binary ].
+            // The reserved octet (bits 64 to 71) is non-zero.
+            [pack('H*', '0064ff9b0001c000ff02210000000000'), pack('H*', 'c0000221'), pack('H*', '0064ff9b0001c0000002210000000000')],
+            // The suffix is non-zero.
+            [pack('H*', '0064ff9b0001c0000002210000000001'), pack('H*', 'c0000221'), pack('H*', '0064ff9b0001c0000002210000000000')],
+        ];
+    }
+}

--- a/tests/Strategy/Nat64Test.php
+++ b/tests/Strategy/Nat64Test.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Darsyn\IP\Tests\Strategy;
+
+use Darsyn\IP\Strategy\Nat64;
+use Darsyn\IP\Tests\DataProvider\Strategy\Nat64 as Nat64DataProvider;
+use Darsyn\IP\Version\IPv6;
+use PHPUnit\Framework\Attributes as PHPUnit;
+use PHPUnit\Framework\TestCase;
+
+class Nat64Test extends TestCase
+{
+    /** @var \Darsyn\IP\Strategy\EmbeddingStrategyInterface $strategy */
+    private $strategy;
+
+    /** @before */
+    #[PHPUnit\Before]
+    protected function setUpWithoutReturnDeclaration(): void
+    {
+        $this->strategy = Nat64::wellKnown();
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getInvalidIpAddresses()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getInvalidIpAddresses')]
+    public function testIsEmbeddedReturnsFalseForAStringOtherThan16BytesLong(string $value): void
+    {
+        $this->assertFalse($this->strategy->isEmbedded($value));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getValidIpAddresses()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getValidIpAddresses')]
+    public function testIsEmbedded(string $value, bool $isEmbedded): void
+    {
+        $this->assertSame($isEmbedded, $this->strategy->isEmbedded($value));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getInvalidIpAddresses()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getInvalidIpAddresses')]
+    public function testExceptionIsThrownWhenTryingToExtractFromStringsNot16Bytes(string $value): void
+    {
+        $this->expectException(\Darsyn\IP\Exception\Strategy\ExtractionException::class);
+        $this->strategy->extract($value);
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getValidSequences()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getValidSequences')]
+    public function testCorrectSequenceExtractedFromIpBinary(string $ipv6, string $ipv4): void
+    {
+        $this->assertSame($ipv4, $this->strategy->extract($ipv6));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getInvalidIpAddresses()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getInvalidIpAddresses')]
+    public function testExceptionIsThrownWhenTryingToPackStringsNot4Bytes(string $value): void
+    {
+        $this->expectException(\Darsyn\IP\Exception\Strategy\PackingException::class);
+        $this->strategy->pack($value);
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getValidSequences()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getValidSequences')]
+    public function testSequenceCorrectlyPackedIntoIpBinaryFromIpBinary(string $ipv6, string $ipv4): void
+    {
+        $this->assertSame($ipv6, $this->strategy->pack($ipv4));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getNetworkSpecificSequences()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getNetworkSpecificSequences')]
+    public function testSequencesEmbedExtractAndPackWithNetworkSpecificPrefixes(string $prefixAddress, int $length, string $ipv6, string $ipv4): void
+    {
+        $strategy = Nat64::networkSpecific(IPv6::factory($prefixAddress), $length);
+        $this->assertTrue($strategy->isEmbedded($ipv6));
+        $this->assertSame($ipv4, $strategy->extract($ipv6));
+        $this->assertSame($ipv6, $strategy->pack($ipv4));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getNonMatchingNetworkSpecificSequences()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getNonMatchingNetworkSpecificSequences')]
+    public function testIsEmbeddedReturnsFalseForSequencesNotMatchingNetworkSpecificPrefix(string $prefixAddress, int $length, string $ipv6): void
+    {
+        $this->assertFalse(Nat64::networkSpecific(IPv6::factory($prefixAddress), $length)->isEmbedded($ipv6));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getNonCanonicalNetworkSpecificSequences()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getNonCanonicalNetworkSpecificSequences')]
+    public function testNonCanonicalSequencesRoundTripToCanonicalFormWithNetworkSpecificPrefixes(string $prefixAddress, int $length, string $nonCanonical, string $ipv4, string $canonical): void
+    {
+        $strategy = Nat64::networkSpecific(IPv6::factory($prefixAddress), $length);
+        $this->assertTrue($strategy->isEmbedded($nonCanonical));
+        $this->assertSame($ipv4, $strategy->extract($nonCanonical));
+        $this->assertSame($canonical, $strategy->pack($strategy->extract($nonCanonical)));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getValidNetworkSpecificArguments()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getValidNetworkSpecificArguments')]
+    public function testNetworkSpecificStrategyCorrectlyConstructed(string $prefixAddress, int $length, string $expectedPrefixHex): void
+    {
+        $strategy = Nat64::networkSpecific(IPv6::factory($prefixAddress), $length);
+        $this->assertSame(pack('H*', $expectedPrefixHex), $strategy->getPrefix());
+        $this->assertSame($length, $strategy->getPrefixLength());
+        $this->assertSame($prefixAddress, IPv6::factory($strategy->getPrefix())->getCompactedAddress());
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getInvalidNetworkSpecificArguments()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getInvalidNetworkSpecificArguments')]
+    public function testExceptionIsThrownForInvalidNetworkSpecificArguments(string $prefixAddress, int $length): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Nat64::networkSpecific(IPv6::factory($prefixAddress), $length);
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getZeroedNetworkSpecificArguments()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getZeroedNetworkSpecificArguments')]
+    public function testBitsSetAfterPrefixLengthAreZeroedForNetworkSpecificPrefixes(string $prefixAddress, int $length, string $expectedPrefixHex): void
+    {
+        $strategy = Nat64::networkSpecific(IPv6::factory($prefixAddress), $length);
+        $this->assertSame(pack('H*', $expectedPrefixHex), $strategy->getPrefix());
+        $this->assertSame($length, $strategy->getPrefixLength());
+    }
+
+    /** @test */
+    #[PHPUnit\Test]
+    public function testWellKnownNamedConstructor(): void
+    {
+        $wellKnown = Nat64::wellKnown();
+        $this->assertSame(pack('H*', Nat64::WELL_KNOWN_PREFIX), $wellKnown->getPrefix());
+        $this->assertSame(96, $wellKnown->getPrefixLength());
+        $this->assertSame('64:ff9b::', IPv6::factory($wellKnown->getPrefix())->getCompactedAddress());
+        $this->assertSame(
+            Nat64::networkSpecific(IPv6::factory('64:ff9b::'), 96)->pack(pack('H*', 'c0000221')),
+            $wellKnown->pack(pack('H*', 'c0000221'))
+        );
+    }
+
+    /** @test */
+    #[PHPUnit\Test]
+    public function testLocalUseNamedConstructor(): void
+    {
+        $localUse = Nat64::localUse();
+        $this->assertSame(pack('H*', Nat64::LOCAL_USE_PREFIX), $localUse->getPrefix());
+        $this->assertSame(48, $localUse->getPrefixLength());
+        $this->assertSame('64:ff9b:1::', IPv6::factory($localUse->getPrefix())->getCompactedAddress());
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getLocalUseSequences()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getLocalUseSequences')]
+    public function testSequencesEmbedExtractAndPackWithLocalUsePrefix(string $ipv6, string $ipv4): void
+    {
+        $strategy = Nat64::localUse();
+        $this->assertTrue($strategy->isEmbedded($ipv6));
+        $this->assertSame($ipv4, $strategy->extract($ipv6));
+        $this->assertSame($ipv6, $strategy->pack($ipv4));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getNonMatchingLocalUseSequences()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getNonMatchingLocalUseSequences')]
+    public function testIsEmbeddedReturnsFalseForSequencesNotMatchingLocalUsePrefix(string $ipv6): void
+    {
+        $this->assertFalse(Nat64::localUse()->isEmbedded($ipv6));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getNonCanonicalLocalUseSequences()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getNonCanonicalLocalUseSequences')]
+    public function testNonCanonicalSequencesRoundTripToCanonicalFormWithLocalUsePrefix(string $nonCanonical, string $ipv4, string $canonical): void
+    {
+        $strategy = Nat64::localUse();
+        $this->assertTrue($strategy->isEmbedded($nonCanonical));
+        $this->assertSame($ipv4, $strategy->extract($nonCanonical));
+        $this->assertSame($canonical, $strategy->pack($strategy->extract($nonCanonical)));
+    }
+}


### PR DESCRIPTION
NAT64 embedding strategy with named constructors for: well-known prefix, local-use prefix, and network-specific prefix.