### PR TITLE
Add Composite embedding strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
   the Well-known Prefix (`64:ff9b::/96`), operator Network-specific Prefixes,
   and the RFC 8215 Local-use prefix (`64:ff9b:1::/48`).
 - Add `Teredo` embedding strategy for `2001::/32` (according to RFC 4380 § 4).
+- Add `Composite` embedding strategy that recognises and extracts version 4
+  addresses across several underlying strategies, while packing through a single
+  canonical strategy.
 
 ## `6.0.0`
 

--- a/docs/05-strategies.md
+++ b/docs/05-strategies.md
@@ -89,3 +89,35 @@ The position of the embedded IPv4 address depends on the prefix length (RFC 6052
 | `/56`       | `PPPP:PPPP:PPPP:PPXX:??XX:XXXX:????:????` |
 | `/64`       | `PPPP:PPPP:PPPP:PPPP:??XX:XXXX:XX??:????` |
 | `/96`       | `PPPP:PPPP:PPPP:PPPP:PPPP:PPPP:XXXX:XXXX` |
+
+## Composite
+
+The `Composite` strategy combines several embedding strategies behind a single
+strategy. An address is recognised as embedded if **any** of the underlying
+strategies recognises it, and extraction is delegated to the **first** strategy
+(in constructor order) that recognises the address.
+
+Packing is asymmetric: only the first strategy supplied — the *packer* — is ever
+used to embed a version 4 address into version 6. A `Composite` can therefore
+recognise several embedding schemes on input while always producing a single
+canonical form on output.
+
+```php
+<?php
+use Darsyn\IP\Strategy\Composite;
+use Darsyn\IP\Strategy\Mapped;
+use Darsyn\IP\Strategy\Nat64;
+use Darsyn\IP\Version\Multi as IP;
+
+// Recognise both IPv4-mapped and NAT64 (Well-known Prefix) embeddings, but
+// always pack as IPv4-mapped.
+$strategy = new Composite(new Mapped, Nat64::wellKnown());
+
+// Addresses embedded under either scheme are recognised as version 4.
+IP::factory('::ffff:7f00:1', $strategy)->getDotAddress();   // string("127.0.0.1")
+IP::factory('64:ff9b::7f00:1', $strategy)->getDotAddress(); // string("127.0.0.1")
+
+// But only the first strategy (here, Mapped) is ever used to pack a version 4
+// address into version 6.
+IP::factory('127.0.0.1', $strategy)->getCompactedAddress(); // string("::ffff:7f00:1")
+```

--- a/src/Strategy/Composite.php
+++ b/src/Strategy/Composite.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Darsyn\IP\Strategy;
+
+use Darsyn\IP\Exception\Strategy as StrategyException;
+
+/**
+ * Aggregates several embedding strategies behind a single strategy. An address
+ * is recognised as embedded if any of the underlying strategies recognises it,
+ * and extraction is delegated to the first strategy (in constructor order) that
+ * recognises the address.
+ *
+ * Packing is asymmetric: only the first strategy supplied (the "packer") is
+ * ever used to embed an IPv4 address into IPv6, so a Composite can recognise
+ * several embedding schemes on input while always producing a single canonical
+ * form on output.
+ */
+class Composite implements EmbeddingStrategyInterface
+{
+    /** @var EmbeddingStrategyInterface $packer */
+    private $packer;
+
+    /** @var list<EmbeddingStrategyInterface> $strategies */
+    private $strategies;
+
+    public function __construct(EmbeddingStrategyInterface $packer, EmbeddingStrategyInterface ...$additional)
+    {
+        $this->packer = $packer;
+        $this->strategies = [$packer];
+        foreach ($additional as $strategy) {
+            $this->strategies[] = $strategy;
+        }
+    }
+
+    public function isEmbedded(string $binary): bool
+    {
+        foreach ($this->strategies as $strategy) {
+            if ($strategy->isEmbedded($binary)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function extract(string $binary): string
+    {
+        foreach ($this->strategies as $strategy) {
+            if ($strategy->isEmbedded($binary)) {
+                return $strategy->extract($binary);
+            }
+        }
+        throw new StrategyException\ExtractionException($binary, $this);
+    }
+
+    public function pack(string $binary): string
+    {
+        return $this->packer->pack($binary);
+    }
+}

--- a/tests/DataProvider/Strategy/Composite.php
+++ b/tests/DataProvider/Strategy/Composite.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Darsyn\IP\Tests\DataProvider\Strategy;
+
+class Composite
+{
+    /** @return list<array{string, bool}> */
+    public static function getValidIpAddresses()
+    {
+        $valid = array_map(static function (array $row) {
+            $row[1] = true;
+            return $row;
+        }, self::getValidSequences());
+        $invalid = array_map(static function (array $row) {
+            $row[1] = false;
+            return $row;
+        }, self::getInvalidSequences());
+        return array_merge($valid, $invalid);
+    }
+
+    /** @return list<array{string}> */
+    public static function getInvalidIpAddresses()
+    {
+        // Strings that are neither 4 nor 16 bytes are rejected identically by
+        // every embedding strategy.
+        return Mapped::getInvalidIpAddresses();
+    }
+
+    /**
+     * The composite under test recognises the Mapped, 6to4 (Derived), NAT64
+     * Well-Known Prefix, and Teredo embeddings, so its valid sequences are the
+     * union of all four.
+     *
+     * @return list<array{string, string}>
+     */
+    public static function getValidSequences()
+    {
+        return array_merge(
+            Mapped::getValidSequences(),
+            Derived::getValidSequences(),
+            Nat64::getValidSequences(),
+            Teredo::getValidSequences()
+        );
+    }
+
+    /**
+     * The composite under test does not include the deprecated "Compatible"
+     * embedding, so addresses embedded only under that scheme must NOT be
+     * recognised.
+     *
+     * @return list<array{string}>
+     */
+    public static function getInvalidSequences()
+    {
+        return array_map(static function (array $row) {
+            return [$row[0]];
+        }, Compatible::getValidSequences());
+    }
+
+    /**
+     * The composite under test always packs using its first (Mapped) strategy,
+     * so only Mapped sequences round-trip through pack().
+     *
+     * @return list<array{string, string}>
+     */
+    public static function getPackableSequences()
+    {
+        return Mapped::getValidSequences();
+    }
+}

--- a/tests/Strategy/CompositeTest.php
+++ b/tests/Strategy/CompositeTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Darsyn\IP\Tests\Strategy;
+
+use Darsyn\IP\Strategy\Composite;
+use Darsyn\IP\Strategy\Derived;
+use Darsyn\IP\Strategy\Mapped;
+use Darsyn\IP\Strategy\Nat64;
+use Darsyn\IP\Strategy\Teredo;
+use Darsyn\IP\Tests\DataProvider\Strategy\Composite as CompositeDataProvider;
+use PHPUnit\Framework\Attributes as PHPUnit;
+use PHPUnit\Framework\TestCase;
+
+class CompositeTest extends TestCase
+{
+    /** @var \Darsyn\IP\Strategy\EmbeddingStrategyInterface $strategy */
+    private $strategy;
+
+    /** @before */
+    #[PHPUnit\Before]
+    protected function setUpWithoutReturnDeclaration(): void
+    {
+        $this->strategy = new Composite(new Mapped(), new Derived(), Nat64::wellKnown(), new Teredo());
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Composite::getInvalidIpAddresses()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(CompositeDataProvider::class, 'getInvalidIpAddresses')]
+    public function testIsEmbeddedReturnsFalseForAStringOtherThan16BytesLong(string $value): void
+    {
+        $this->assertFalse($this->strategy->isEmbedded($value));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Composite::getValidIpAddresses()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(CompositeDataProvider::class, 'getValidIpAddresses')]
+    public function testIsEmbedded(string $value, bool $isEmbedded): void
+    {
+        $this->assertSame($isEmbedded, $this->strategy->isEmbedded($value));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Composite::getInvalidIpAddresses()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(CompositeDataProvider::class, 'getInvalidIpAddresses')]
+    public function testExceptionIsThrownWhenTryingToExtractFromStringsNot16Bytes(string $value): void
+    {
+        $this->expectException(\Darsyn\IP\Exception\Strategy\ExtractionException::class);
+        $this->strategy->extract($value);
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Composite::getValidSequences()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(CompositeDataProvider::class, 'getValidSequences')]
+    public function testCorrectSequenceExtractedFromIpBinary(string $ipv6, string $ipv4): void
+    {
+        $this->assertSame($ipv4, $this->strategy->extract($ipv6));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Composite::getInvalidIpAddresses()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(CompositeDataProvider::class, 'getInvalidIpAddresses')]
+    public function testExceptionIsThrownWhenTryingToPackStringsNot4Bytes(string $value): void
+    {
+        $this->expectException(\Darsyn\IP\Exception\Strategy\PackingException::class);
+        $this->strategy->pack($value);
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Composite::getPackableSequences()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(CompositeDataProvider::class, 'getPackableSequences')]
+    public function testSequenceCorrectlyPackedIntoIpBinaryFromIpBinary(string $ipv6, string $ipv4): void
+    {
+        $this->assertSame($ipv6, $this->strategy->pack($ipv4));
+    }
+}


### PR DESCRIPTION
Strategy that delegates detection and extraction to several underlying strategies (first match wins), while packing through a single canonical (first-passed) strategy.