### PR TITLE
Add byte-string arithmetic to Binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## `6.x`
 
+- Add arithmetic primitives to `Util\Binary`: `increment()`, `decrement()` and
+  `addIntegerOffset()`. Over/underflowing throws new exception.
 - Add support for PHP `8.5` in README, and GitHub Action CI workflows.
 - Access protected method via Closure in unit tests, instead of reflection, to
   fix deprecation warnings in PHP `8.5`.

--- a/src/Exception/OverflowException.php
+++ b/src/Exception/OverflowException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Darsyn\IP\Exception;
+
+class OverflowException extends IpException
+{
+    public function __construct(?\Throwable $previous = null)
+    {
+        parent::__construct('The arithmetic operation overflowed the bounds of the address space.', 0, $previous);
+    }
+}

--- a/src/Util/Binary.php
+++ b/src/Util/Binary.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Darsyn\IP\Util;
 
+use Darsyn\IP\Exception\OverflowException;
+
 class Binary
 {
     /** @throws \InvalidArgumentException */
@@ -44,5 +46,41 @@ class Binary
         return \implode('', \array_map(static function ($character) {
             return MbString::padString(\decbin((int) \hexdec($character)), 8, '0', \STR_PAD_LEFT);
         }, \function_exists('mb_str_split') ? \mb_str_split($hex, 2, '8bit') : \str_split($hex, 2)));
+    }
+
+    /** @throws \Darsyn\IP\Exception\OverflowException */
+    public static function increment(string $binary): string
+    {
+        return static::addIntegerOffset($binary, 1);
+    }
+
+    /** @throws \Darsyn\IP\Exception\OverflowException */
+    public static function decrement(string $binary): string
+    {
+        return static::addIntegerOffset($binary, -1);
+    }
+
+    /**
+     * Add a signed integer offset to a fixed-length binary string, preserving
+     * its byte length. Essentially a base-256 plus or minus base-10 operation.
+     *
+     * @throws \Darsyn\IP\Exception\OverflowException
+     */
+    public static function addIntegerOffset(string $binary, int $offset): string
+    {
+        $carry = $offset;
+        for ($i = MbString::getLength($binary) - 1; $i >= 0; $i--) {
+            if (0 === $carry) {
+                break;
+            }
+            $total = \ord($binary[$i]) + $carry % 256;
+            $byte = $total & 0xff;
+            $binary[$i] = \chr($byte);
+            $carry = \intdiv($carry, 256) + \intdiv($total - $byte, 256);
+        }
+        if (0 !== $carry) {
+            throw new OverflowException();
+        }
+        return $binary;
     }
 }

--- a/tests/DataProvider/Util/Binary.php
+++ b/tests/DataProvider/Util/Binary.php
@@ -55,4 +55,91 @@ class Binary
             ['101 011'],
         ];
     }
+
+    /** @return list<array{string, string}> */
+    public static function getIncrementData()
+    {
+        return [
+            // [input, expected]
+            ['00000000', '00000001'],
+            ['000000ff', '00000100'],
+            ['0000ffff', '00010000'],
+            ['fffffffe', 'ffffffff'],
+            ['7fffffff', '80000000'],
+            ['000000000000000000000000000000ff', '00000000000000000000000000000100'],
+            ['fffffffffffffffffffffffffffffffe', 'ffffffffffffffffffffffffffffffff'],
+        ];
+    }
+
+    /** @return list<array{string, string}> */
+    public static function getDecrementData()
+    {
+        return [
+            // [input, expected]
+            ['00000001', '00000000'],
+            ['00000100', '000000ff'],
+            ['00010000', '0000ffff'],
+            ['ffffffff', 'fffffffe'],
+            ['80000000', '7fffffff'],
+            ['00000000000000000000000000000100', '000000000000000000000000000000ff'],
+            ['ffffffffffffffffffffffffffffffff', 'fffffffffffffffffffffffffffffffe'],
+        ];
+    }
+
+    /** @return list<array{string, int, string}> */
+    public static function getOffsetData()
+    {
+        return [
+            // [input, offset, expected]
+            ['12345678', 0, '12345678'],
+            ['00000000', 1, '00000001'],
+            ['00000000', 255, '000000ff'],
+            ['00000000', 256, '00000100'],
+            ['00000000', 65535, '0000ffff'],
+            ['0000ffff', 1, '00010000'],
+            ['ffffffff', -1, 'fffffffe'],
+            ['00000100', -256, '00000000'],
+            ['7fffffff', 1, '80000000'],
+            ['80000000', -1, '7fffffff'],
+            // Full 64-bit offsets, including the PHP_INT_MIN edge that cannot be
+            // negated without overflow.
+            ['0000000000000000', \PHP_INT_MAX, '7fffffffffffffff'],
+            ['8000000000000000', \PHP_INT_MIN, '0000000000000000'],
+            ['ffffffffffffffff', \PHP_INT_MIN, '7fffffffffffffff'],
+        ];
+    }
+
+    /** @return list<array{string}> */
+    public static function getIncrementOverflowData()
+    {
+        return [
+            ['ffffffff'],
+            ['ffffffffffffffffffffffffffffffff'],
+            ['ff'],
+        ];
+    }
+
+    /** @return list<array{string}> */
+    public static function getDecrementUnderflowData()
+    {
+        return [
+            ['00000000'],
+            ['00000000000000000000000000000000'],
+            ['00'],
+        ];
+    }
+
+    /** @return list<array{string, int}> */
+    public static function getOffsetOverflowData()
+    {
+        return [
+            // [input, offset]
+            ['ffffffff', 1],
+            ['00000000', -1],
+            ['00000001', -2],
+            ['fffffffe', 2],
+            ['ffffffffffffffff', 1],
+            ['0000000000000000', -1],
+        ];
+    }
 }

--- a/tests/Util/BinaryTest.php
+++ b/tests/Util/BinaryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\Util;
 
+use Darsyn\IP\Exception\OverflowException;
 use Darsyn\IP\Tests\DataProvider\Util\Binary as BinaryDataProvider;
 use Darsyn\IP\Util\Binary;
 use PHPUnit\Framework\Attributes as PHPUnit;
@@ -95,5 +96,88 @@ class BinaryTest extends TestCase
     {
         $converted = Binary::fromHumanReadable($humanReadable);
         $this->assertSame(\strtolower($hex), Binary::toHex($converted));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Util\Binary::getIncrementData()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(BinaryDataProvider::class, 'getIncrementData')]
+    public function testIncrement(string $input, string $expected): void
+    {
+        $this->assertSame($expected, Binary::toHex(Binary::increment(Binary::fromHex($input))));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Util\Binary::getDecrementData()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(BinaryDataProvider::class, 'getDecrementData')]
+    public function testDecrement(string $input, string $expected): void
+    {
+        $this->assertSame($expected, Binary::toHex(Binary::decrement(Binary::fromHex($input))));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Util\Binary::getOffsetData()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(BinaryDataProvider::class, 'getOffsetData')]
+    public function testAddIntegerOffset(string $input, int $offset, string $expected): void
+    {
+        $this->assertSame($expected, Binary::toHex(Binary::addIntegerOffset(Binary::fromHex($input), $offset)));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Util\Binary::getIncrementOverflowData()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(BinaryDataProvider::class, 'getIncrementOverflowData')]
+    public function testIncrementOverflowThrows(string $input): void
+    {
+        $this->expectException(OverflowException::class);
+        Binary::increment(Binary::fromHex($input));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Util\Binary::getDecrementUnderflowData()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(BinaryDataProvider::class, 'getDecrementUnderflowData')]
+    public function testDecrementUnderflowThrows(string $input): void
+    {
+        $this->expectException(OverflowException::class);
+        Binary::decrement(Binary::fromHex($input));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Util\Binary::getOffsetOverflowData()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(BinaryDataProvider::class, 'getOffsetOverflowData')]
+    public function testAddIntegerOffsetOverflowThrows(string $input, int $offset): void
+    {
+        $this->expectException(OverflowException::class);
+        Binary::addIntegerOffset(Binary::fromHex($input), $offset);
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Util\Binary::getBinaryData()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(BinaryDataProvider::class, 'getBinaryData')]
+    public function testArithmeticRoundTrips(string $hex, string $humanReadable): void
+    {
+        $binary = Binary::fromHex($hex);
+        $this->assertSame($binary, Binary::decrement(Binary::increment($binary)));
+        $this->assertSame($binary, Binary::increment(Binary::decrement($binary)));
+        $this->assertSame($binary, Binary::addIntegerOffset($binary, 0));
     }
 }


### PR DESCRIPTION
- Add length-preserving `increment()`, `decrement()` and `addIntegerOffset()` primitives to `Util\Binary`.
- Propagates from the least-significant byte upwards.
- Update tests and data providers.
- Update CHANGELOG.