### PR TITLE
Contracts: extract experimental capability interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## `6.x`
 
+- Introduce `@experimental` capability interfaces under `Darsyn\IP\Contracts\`.
+  Their shape may change before `7.0`, but remains backwards compatible for `6.x`
 - Allow overriding the global formatter per call by passing a
   `Formatter\ProtocolFormatterInterface` as the first argument to
   `IPv4::getDotAddress()`, `IPv6::getCompactedAddress()`,

--- a/src/Contracts/ArithmeticInterface.php
+++ b/src/Contracts/ArithmeticInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Darsyn\IP\Contracts;
+
+/**
+ * @experimental
+ */
+interface ArithmeticInterface
+{
+    /**
+     * Get Network Address
+     *
+     * Get a new value object from the network address of the original IP.
+     *
+     * @throws \Darsyn\IP\Exception\InvalidCidrException
+     * @return static
+     */
+    public function getNetworkIp(int $cidr);
+
+    /**
+     * Get Broadcast Address
+     *
+     * Get a new value object from the broadcast address of the original IP.
+     *
+     * @throws \Darsyn\IP\Exception\InvalidCidrException
+     * @return static
+     */
+    public function getBroadcastIp(int $cidr);
+}

--- a/src/Contracts/Classification4Interface.php
+++ b/src/Contracts/Classification4Interface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Darsyn\IP\Contracts;
+
+/**
+ * @experimental
+ */
+interface Classification4Interface extends ClassificationInterface
+{
+    /**
+     * Whether the IP is a broadcast address, according to RFC 919 § 7.
+     *
+     * @throws \Darsyn\IP\Exception\WrongVersionException
+     */
+    public function isBroadcast(): bool;
+
+    /**
+     * Whether the IP is part of the Shared Address Space, according to RFC 6598.
+     *
+     * @throws \Darsyn\IP\Exception\WrongVersionException
+     */
+    public function isShared(): bool;
+
+    /**
+     * Whether the IP is reserved for future use, according to RFC 1112 § 4
+     * (excluding the limited broadcast address, which is a separate
+     * special-purpose registry entry per RFC 8190).
+     *
+     * @throws \Darsyn\IP\Exception\WrongVersionException
+     */
+    public function isFutureReserved(): bool;
+}

--- a/src/Contracts/Classification6Interface.php
+++ b/src/Contracts/Classification6Interface.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Darsyn\IP\Contracts;
+
+/**
+ * @experimental
+ */
+interface Classification6Interface extends ClassificationInterface
+{
+    // Multicast scope field values, as defined by RFC 7346 § 2 (which updated
+    // the original RFC 4291 § 2.7 table; realm-local scope 3 is only defined
+    // in RFC 7346).
+    public const MULTICAST_INTERFACE_LOCAL = 1;
+    public const MULTICAST_LINK_LOCAL = 2;
+    public const MULTICAST_REALM_LOCAL = 3;
+    public const MULTICAST_ADMIN_LOCAL = 4;
+    public const MULTICAST_SITE_LOCAL = 5;
+    public const MULTICAST_ORGANIZATION_LOCAL = 8;
+    public const MULTICAST_GLOBAL = 14;
+
+    /**
+     * Returns the IP address’s multicast scope if the address is multicast,
+     * null otherwise. Return values are integers mapped to the MULTICAST_*
+     * constants on this interface, with scope values defined by RFC 7346 § 2.
+     */
+    public function getMulticastScope(): ?int;
+
+    /** Whether the IP is a unique local address, according to RFC 4193. */
+    public function isUniqueLocal(): bool;
+
+    /** Whether the IP is a unicast address, according to RFC 4291. */
+    public function isUnicast(): bool;
+
+    /**
+     * Whether the IP is a globally routable unicast address, according to
+     * RFC 4291 § 2.5.4.
+     */
+    public function isUnicastGlobal(): bool;
+}

--- a/src/Contracts/ClassificationInterface.php
+++ b/src/Contracts/ClassificationInterface.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Darsyn\IP\Contracts;
+
+/**
+ * @experimental
+ */
+interface ClassificationInterface
+{
+    /**
+     * Whether the IP is reserved for link-local usage, according to RFC 3927
+     * (IPv4) or RFC 4291 § 2.5.6 (IPv6).
+     */
+    public function isLinkLocal(): bool;
+
+    /**
+     * Whether the IP is a loopback address, according to RFC 1122 § 3.2.1.3
+     * (IPv4) or RFC 4291 § 2.5.3 (IPv6).
+     */
+    public function isLoopback(): bool;
+
+    /**
+     * Whether the IP is a multicast address, according to RFC 5771 (IPv4) or
+     * RFC 4291 § 2.7 (IPv6).
+     */
+    public function isMulticast(): bool;
+
+    /**
+     * Whether the IP is for private use, according to RFC 1918/RFC 4193
+     * (IPv4/IPv6).
+     */
+    public function isPrivateUse(): bool;
+
+    /**
+     * Whether the IP is unspecified ("this host on this network"), according
+     * to RFC 1122 § 3.2.1.3 (IPv4) or RFC 4291 § 2.5.2 (IPv6).
+     */
+    public function isUnspecified(): bool;
+
+    /**
+     * Whether the IP is reserved for network devices benchmarking, according
+     * to RFC 2544 (IPv4) or RFC 5180 (IPv6). The IPv6 block printed in RFC 5180
+     * itself is wrong; RFC Errata 1752 corrects it to `2001:2::/48`.
+     */
+    public function isBenchmarking(): bool;
+
+    /**
+     * Whether the IP is in a range designated for documentation, according to
+     * RFC 5737 and RFC 5771 § 9.2 (IPv4), or RFC 3849 and RFC 9637 (IPv6).
+     */
+    public function isDocumentation(): bool;
+
+    /**
+     * Whether the IP appears to be publicly/globally routable. Please refer to
+     * the IANA Special-Purpose Address Registry documents.
+     *
+     * @see https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+     * @see https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
+     */
+    public function isGloballyReachable(): bool;
+}

--- a/src/Contracts/ComparisonInterface.php
+++ b/src/Contracts/ComparisonInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Darsyn\IP\Contracts;
+
+use Darsyn\IP\IpInterface;
+
+/**
+ * @experimental
+ */
+interface ComparisonInterface
+{
+    /** Do two IP objects represent the same IP address? */
+    public function equals(IpInterface $ip): bool;
+
+    /**
+     * Is IP Address In Range?
+     *
+     * Returns a boolean value depending on whether the IP address in question
+     * is within the range of the target IP/CIDR combination.
+     * Comparing two IPs of different byte-lengths (IPv4 vs IPv6/IPv4-embedded)
+     * will throw a WrongVersionException.
+     *
+     * @throws \Darsyn\IP\Exception\InvalidCidrException
+     * @throws \Darsyn\IP\Exception\WrongVersionException
+     */
+    public function inRange(IpInterface $ip, int $cidr): bool;
+
+    /**
+     * Get Common CIDR Between IP Addresses
+     *
+     * Returns the highest common CIDR between the current IP address and
+     * another.
+     *
+     * @throws \Darsyn\IP\Exception\WrongVersionException
+     */
+    public function getCommonCidr(IpInterface $ip): int;
+}

--- a/src/Contracts/Output4Interface.php
+++ b/src/Contracts/Output4Interface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Darsyn\IP\Contracts;
+
+/**
+ * @experimental
+ */
+interface Output4Interface extends OutputInterface
+{
+    /**
+     * Get Dot Address
+     *
+     * Convert an IP into an IPv4 dot-notation address string
+     * This method will NOT work with IPv6 addresses.
+     *
+     * @throws \Darsyn\IP\Exception\IpException
+     * @throws \Darsyn\IP\Exception\WrongVersionException
+     */
+    public function getDotAddress(): string;
+}

--- a/src/Contracts/Output6Interface.php
+++ b/src/Contracts/Output6Interface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Darsyn\IP\Contracts;
+
+/**
+ * @experimental
+ */
+interface Output6Interface extends OutputInterface
+{
+    /**
+     * Get Compacted Address
+     *
+     * Converts an IP (regardless of version) into a compacted IPv6 address
+     * (including double-colons if appropriate).
+     *
+     * @throws \Darsyn\IP\Exception\IpException
+     */
+    public function getCompactedAddress(): string;
+
+    /**
+     * Get Expanded Address
+     *
+     * Converts an IP (regardless of version) address into a full IPv6 address
+     * (no double colons).
+     *
+     * @throws \Darsyn\IP\Exception\IpException
+     */
+    public function getExpandedAddress(): string;
+}

--- a/src/Contracts/OutputInterface.php
+++ b/src/Contracts/OutputInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Darsyn\IP\Contracts;
+
+/**
+ * @experimental
+ */
+interface OutputInterface
+{
+    /** Get Binary Representation */
+    public function getBinary(): string;
+
+    /** Implement string casting for IP objects. */
+    public function __toString(): string;
+}

--- a/src/Contracts/VersionIdentityInterface.php
+++ b/src/Contracts/VersionIdentityInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Darsyn\IP\Contracts;
+
+/**
+ * @experimental
+ */
+interface VersionIdentityInterface
+{
+    /** Get the IP version from the binary value */
+    public function getVersion(): int;
+
+    /** Is Version? */
+    public function isVersion(int $version): bool;
+
+    /** Whether the IP is version 4 */
+    public function isVersion4(): bool;
+
+    /** Whether the IP is version 6 */
+    public function isVersion6(): bool;
+}

--- a/src/IpInterface.php
+++ b/src/IpInterface.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Darsyn\IP;
 
-interface IpInterface
+use Darsyn\IP\Contracts\ArithmeticInterface;
+use Darsyn\IP\Contracts\ClassificationInterface;
+use Darsyn\IP\Contracts\ComparisonInterface;
+use Darsyn\IP\Contracts\OutputInterface;
+use Darsyn\IP\Contracts\VersionIdentityInterface;
+
+interface IpInterface extends ArithmeticInterface, ClassificationInterface, ComparisonInterface, OutputInterface, VersionIdentityInterface
 {
     /**
      * @throws \Darsyn\IP\Exception\InvalidIpAddressException
@@ -12,66 +18,6 @@ interface IpInterface
      * @return static
      */
     public static function factory(string $ip);
-
-    /** Get Binary Representation */
-    public function getBinary(): string;
-
-    /** Do two IP objects represent the same IP address? */
-    public function equals(self $ip): bool;
-
-    /** Get the IP version from the binary value */
-    public function getVersion(): int;
-
-    /** Is Version? */
-    public function isVersion(int $version): bool;
-
-    /** Whether the IP is version 4 */
-    public function isVersion4(): bool;
-
-    /** Whether the IP is version 6 */
-    public function isVersion6(): bool;
-
-    /**
-     * Get Network Address
-     *
-     * Get a new value object from the network address of the original IP.
-     *
-     * @throws \Darsyn\IP\Exception\InvalidCidrException
-     * @return static
-     */
-    public function getNetworkIp(int $cidr);
-
-    /**
-     * Get Broadcast Address
-     *
-     * Get a new value object from the broadcast address of the original IP.
-     *
-     * @throws \Darsyn\IP\Exception\InvalidCidrException
-     * @return static
-     */
-    public function getBroadcastIp(int $cidr);
-
-    /**
-     * Is IP Address In Range?
-     *
-     * Returns a boolean value depending on whether the IP address in question
-     * is within the range of the target IP/CIDR combination.
-     * Comparing two IPs of different byte-lengths (IPv4 vs IPv6/IPv4-embedded)
-     * will throw a WrongVersionException.
-     *
-     * @throws \Darsyn\IP\Exception\InvalidCidrException
-     * @throws \Darsyn\IP\Exception\WrongVersionException
-     */
-    public function inRange(self $ip, int $cidr): bool;
-
-    /**
-     * Get Common CIDR Between IP Addresses
-     *
-     * Returns the highest common CIDR between the current IP address and another
-     *
-     * @throws \Darsyn\IP\Exception\WrongVersionException
-     */
-    public function getCommonCidr(self $ip): int;
 
     /**
      * Whether the IP is an IPv4-mapped IPv6 address, according to
@@ -99,65 +45,10 @@ interface IpInterface
     public function isEmbedded(): bool;
 
     /**
-     * Whether the IP is reserved for link-local usage, according to RFC 3927
-     * (IPv4) or RFC 4291 § 2.5.6 (IPv6).
-     */
-    public function isLinkLocal(): bool;
-
-    /**
-     * Whether the IP is a loopback address, according to RFC 1122 § 3.2.1.3
-     * (IPv4) or RFC 4291 § 2.5.3 (IPv6).
-     */
-    public function isLoopback(): bool;
-
-    /**
-     * Whether the IP is a multicast address, according to RFC 5771 (IPv4) or
-     * RFC 4291 § 2.7 (IPv6).
-     */
-    public function isMulticast(): bool;
-
-    /**
-     * Whether the IP is for private use, according to RFC 1918/RFC 4193
-     * (IPv4/IPv6).
-     */
-    public function isPrivateUse(): bool;
-
-    /**
-     * Whether the IP is unspecified ("this host on this network"), according
-     * to RFC 1122 § 3.2.1.3 (IPv4) or RFC 4291 § 2.5.2 (IPv6).
-     */
-    public function isUnspecified(): bool;
-
-    /**
-     * Whether the IP is reserved for network devices benchmarking, according
-     * to RFC 2544 (IPv4) or RFC 5180 (IPv6). The IPv6 block printed in RFC 5180
-     * itself is wrong; RFC Errata 1752 corrects it to `2001:2::/48`.
-     */
-    public function isBenchmarking(): bool;
-
-    /**
-     * Whether the IP is in a range designated for documentation, according to
-     * RFC 5737 and RFC 5771 § 9.2 (IPv4), or RFC 3849 and RFC 9637 (IPv6).
-     */
-    public function isDocumentation(): bool;
-
-    /**
      * Superseded by `isGloballyReachable()` which conforms to official wording;
      * "Public Use" does not appear in the IANA special-purpose registries.
      *
      * @deprecated Use isGloballyReachable() instead.
      */
     public function isPublicUse(): bool;
-
-    /**
-     * Whether the IP appears to be publicly/globally routable. Please refer to
-     * the IANA Special-Purpose Address Registry documents.
-     *
-     * @see https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
-     * @see https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
-     */
-    public function isGloballyReachable(): bool;
-
-    /** Implement string casting for IP objects. */
-    public function __toString(): string;
 }

--- a/src/Version/Version4Interface.php
+++ b/src/Version/Version4Interface.php
@@ -4,41 +4,8 @@ declare(strict_types=1);
 
 namespace Darsyn\IP\Version;
 
+use Darsyn\IP\Contracts\Classification4Interface;
+use Darsyn\IP\Contracts\Output4Interface;
 use Darsyn\IP\IpInterface;
 
-interface Version4Interface extends IpInterface
-{
-    /**
-     * Get Dot Address
-     *
-     * Convert an IP into an IPv4 dot-notation address string
-     * This method will NOT work with IPv6 addresses.
-     *
-     * @throws \Darsyn\IP\Exception\IpException
-     * @throws \Darsyn\IP\Exception\WrongVersionException
-     */
-    public function getDotAddress(): string;
-
-    /**
-     * Whether the IP is a broadcast address, according to RFC 919 § 7.
-     *
-     * @throws \Darsyn\IP\Exception\WrongVersionException
-     */
-    public function isBroadcast(): bool;
-
-    /**
-     * Whether the IP is part of the Shared Address Space, according to RFC 6598.
-     *
-     * @throws \Darsyn\IP\Exception\WrongVersionException
-     */
-    public function isShared(): bool;
-
-    /**
-     * Whether the IP is reserved for future use, according to RFC 1112 § 4
-     * (excluding the limited broadcast address, which is a separate
-     * special-purpose registry entry per RFC 8190).
-     *
-     * @throws \Darsyn\IP\Exception\WrongVersionException
-     */
-    public function isFutureReserved(): bool;
-}
+interface Version4Interface extends IpInterface, Classification4Interface, Output4Interface {}

--- a/src/Version/Version6Interface.php
+++ b/src/Version/Version6Interface.php
@@ -4,57 +4,8 @@ declare(strict_types=1);
 
 namespace Darsyn\IP\Version;
 
+use Darsyn\IP\Contracts\Classification6Interface;
+use Darsyn\IP\Contracts\Output6Interface;
 use Darsyn\IP\IpInterface;
 
-interface Version6Interface extends IpInterface
-{
-    // Multicast scope field values, as defined by RFC 7346 § 2 (which updated
-    // the original RFC 4291 § 2.7 table; realm-local scope 3 is only defined
-    // in RFC 7346).
-    public const MULTICAST_INTERFACE_LOCAL = 1;
-    public const MULTICAST_LINK_LOCAL = 2;
-    public const MULTICAST_REALM_LOCAL = 3;
-    public const MULTICAST_ADMIN_LOCAL = 4;
-    public const MULTICAST_SITE_LOCAL = 5;
-    public const MULTICAST_ORGANIZATION_LOCAL = 8;
-    public const MULTICAST_GLOBAL = 14;
-
-    /**
-     * Get Compacted Address
-     *
-     * Converts an IP (regardless of version) into a compacted IPv6 address
-     * (including double-colons if appropriate).
-     *
-     * @throws \Darsyn\IP\Exception\IpException
-     */
-    public function getCompactedAddress(): string;
-
-    /**
-     * Get Expanded Address
-     *
-     * Converts an IP (regardless of version) address into a full IPv6 address
-     * (no double colons).
-     *
-     * @throws \Darsyn\IP\Exception\IpException
-     */
-    public function getExpandedAddress(): string;
-
-    /**
-     * Returns the IP address’s multicast scope if the address is multicast,
-     * null otherwise. Return values are integers mapped to the MULTICAST_*
-     * constants on this interface, with scope values defined by RFC 7346 § 2.
-     */
-    public function getMulticastScope(): ?int;
-
-    /** Whether the IP is a unique local address, according to RFC 4193. */
-    public function isUniqueLocal(): bool;
-
-    /** Whether the IP is a unicast address, according to RFC 4291. */
-    public function isUnicast(): bool;
-
-    /**
-     * Whether the IP is a globally routable unicast address, according to
-     * RFC 4291 § 2.5.4.
-     */
-    public function isUnicastGlobal(): bool;
-}
+interface Version6Interface extends IpInterface, Classification6Interface, Output6Interface {}

--- a/tests/Version/IPv4Test.php
+++ b/tests/Version/IPv4Test.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\Version;
 
+use Darsyn\IP\Contracts\ArithmeticInterface;
+use Darsyn\IP\Contracts\Classification4Interface;
+use Darsyn\IP\Contracts\ClassificationInterface;
+use Darsyn\IP\Contracts\ComparisonInterface;
+use Darsyn\IP\Contracts\Output4Interface;
+use Darsyn\IP\Contracts\OutputInterface;
+use Darsyn\IP\Contracts\VersionIdentityInterface;
 use Darsyn\IP\Exception\InvalidCidrException;
 use Darsyn\IP\Exception\InvalidIpAddressException;
 use Darsyn\IP\Exception\WrongVersionException;
@@ -25,6 +32,20 @@ class IPv4Test extends TestCase
     public function resetProtocolFormatter(): void
     {
         IP::setProtocolFormatter(new ConsistentFormatter());
+    }
+
+    /** @test */
+    #[PHPUnit\Test]
+    public function testImplementsCapabilityInterfaces(): void
+    {
+        $ip = IP::factory('127.0.0.1');
+        $this->assertInstanceOf(VersionIdentityInterface::class, $ip);
+        $this->assertInstanceOf(ComparisonInterface::class, $ip);
+        $this->assertInstanceOf(ArithmeticInterface::class, $ip);
+        $this->assertInstanceOf(OutputInterface::class, $ip);
+        $this->assertInstanceOf(Output4Interface::class, $ip);
+        $this->assertInstanceOf(ClassificationInterface::class, $ip);
+        $this->assertInstanceOf(Classification4Interface::class, $ip);
     }
 
     /**

--- a/tests/Version/IPv6Test.php
+++ b/tests/Version/IPv6Test.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\Version;
 
+use Darsyn\IP\Contracts\ArithmeticInterface;
+use Darsyn\IP\Contracts\Classification6Interface;
+use Darsyn\IP\Contracts\ClassificationInterface;
+use Darsyn\IP\Contracts\ComparisonInterface;
+use Darsyn\IP\Contracts\Output6Interface;
+use Darsyn\IP\Contracts\OutputInterface;
+use Darsyn\IP\Contracts\VersionIdentityInterface;
 use Darsyn\IP\Exception\InvalidCidrException;
 use Darsyn\IP\Exception\InvalidIpAddressException;
 use Darsyn\IP\Exception\WrongVersionException;
@@ -29,6 +36,20 @@ class IPv6Test extends TestCase
     public function resetProtocolFormatter(): void
     {
         IP::setProtocolFormatter(new ConsistentFormatter());
+    }
+
+    /** @test */
+    #[PHPUnit\Test]
+    public function testImplementsCapabilityInterfaces(): void
+    {
+        $ip = IP::factory('::1');
+        $this->assertInstanceOf(VersionIdentityInterface::class, $ip);
+        $this->assertInstanceOf(ComparisonInterface::class, $ip);
+        $this->assertInstanceOf(ArithmeticInterface::class, $ip);
+        $this->assertInstanceOf(OutputInterface::class, $ip);
+        $this->assertInstanceOf(Output6Interface::class, $ip);
+        $this->assertInstanceOf(ClassificationInterface::class, $ip);
+        $this->assertInstanceOf(Classification6Interface::class, $ip);
     }
 
     /**

--- a/tests/Version/MultiTest.php
+++ b/tests/Version/MultiTest.php
@@ -4,6 +4,15 @@ declare(strict_types=1);
 
 namespace Darsyn\IP\Tests\Version;
 
+use Darsyn\IP\Contracts\ArithmeticInterface;
+use Darsyn\IP\Contracts\Classification4Interface;
+use Darsyn\IP\Contracts\Classification6Interface;
+use Darsyn\IP\Contracts\ClassificationInterface;
+use Darsyn\IP\Contracts\ComparisonInterface;
+use Darsyn\IP\Contracts\Output4Interface;
+use Darsyn\IP\Contracts\Output6Interface;
+use Darsyn\IP\Contracts\OutputInterface;
+use Darsyn\IP\Contracts\VersionIdentityInterface;
 use Darsyn\IP\Exception\InvalidIpAddressException;
 use Darsyn\IP\Exception\WrongVersionException;
 use Darsyn\IP\Formatter\ConsistentFormatter;
@@ -34,6 +43,22 @@ class MultiTest extends TestCase
     public function resetProtocolFormatter(): void
     {
         IP::setProtocolFormatter(new ConsistentFormatter());
+    }
+
+    /** @test */
+    #[PHPUnit\Test]
+    public function testImplementsCapabilityInterfaces(): void
+    {
+        $ip = IP::factory('127.0.0.1');
+        $this->assertInstanceOf(VersionIdentityInterface::class, $ip);
+        $this->assertInstanceOf(ComparisonInterface::class, $ip);
+        $this->assertInstanceOf(ArithmeticInterface::class, $ip);
+        $this->assertInstanceOf(OutputInterface::class, $ip);
+        $this->assertInstanceOf(Output4Interface::class, $ip);
+        $this->assertInstanceOf(Output6Interface::class, $ip);
+        $this->assertInstanceOf(ClassificationInterface::class, $ip);
+        $this->assertInstanceOf(Classification4Interface::class, $ip);
+        $this->assertInstanceOf(Classification6Interface::class, $ip);
     }
 
     /**


### PR DESCRIPTION
- Introduce composable capability interfaces under `Darsyn\IP\Contracts\`.
- Tagged `@experimental` ahead of the 7.0 interface decomposition.