### PR TITLE
Detect embedding strategies and extract the address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## `6.x`
 
+- Detect embedding strategies via the new `Contracts\StrategyDetectionInterface`
+  deprecating the old `IpInterface::isEmbedded()` and associated methods.
 - Convert IP addresses to and from integers: `fromInteger()`/`toInteger()` via
   the new `Contracts\Factory4Interface` (IPv4 and Multi only), plus
   arbitrary-precision `fromIntegerString()`/`toIntegerString()` and fixed-width

--- a/docs/07-types.md
+++ b/docs/07-types.md
@@ -79,6 +79,69 @@ $ip = IP::factory('::7f00:1');
 $ip->isCompatible(); // bool(true)
 ```
 
+### NAT64
+
+Whether the IP is a NAT64 address within the Well-Known Prefix `64:ff9b::/96`,
+according to [RFC 6052 section 2.1](https://tools.ietf.org/html/rfc6052 "IPv6
+Addressing of IPv4/IPv6 Translators"), or within the Local-use Prefix
+`64:ff9b:1::/48`, according to [RFC 8215 section 4](https://tools.ietf.org/html/rfc8215
+"Local-Use IPv4/IPv6 Translation Prefix").
+
+```php
+<?php
+use Darsyn\IP\Version\IPv6 as IP;
+
+IP::fromProtocol('64:ff9b::7f00:1')->isNat64WellKnown(); // bool(true)
+IP::fromProtocol('64:ff9b:1:7f00:0:1::')->isNat64LocalUse(); // bool(true)
+```
+
+### Teredo
+
+Whether the IP is a Teredo tunnelling address within `2001::/32`, according to
+[RFC 4380 section 4](https://tools.ietf.org/html/rfc4380 "Teredo: Tunneling
+IPv6 over UDP through NATs").
+
+```php
+<?php
+use Darsyn\IP\Version\IPv6 as IP;
+
+$ip = IP::fromProtocol('2001::8500:0:0:80ff:fffe');
+$ip->isTeredo(); // bool(true)
+```
+
+### According to Any Strategy
+
+`isEmbeddedAccordingToStrategy()` is the generic form of the named detection
+predicates: any [embedding strategy](./05-strategies.md), including a
+user-defined one, can be tested against the address without constructing a new
+IP object around it.
+
+```php
+<?php
+use Darsyn\IP\Strategy\Derived;
+use Darsyn\IP\Version\IPv6 as IP;
+
+$ip = IP::fromProtocol('2002:7f00:1::');
+$ip->isEmbeddedAccordingToStrategy(new Derived()); // bool(true)
+```
+
+### Embedded IP
+
+`getEmbeddedIp()` extracts the IPv4 address embedded in this address as an
+`IPv4` instance, and the inverse of `IPv6::fromEmbedded()`. A
+`WrongVersionException` is thrown when no IPv4 address is embedded according to
+the strategy in effect. A null strategy falls back to the instance's own
+embedding strategy on `Multi`, or to the global default set via
+`Multi::setDefaultEmbeddingStrategy()`
+
+```php
+<?php
+use Darsyn\IP\Version\Multi as IP;
+
+$ip = IP::fromProtocol('::ffff:7f00:1');
+$ip->getEmbeddedIp()->getDotAddress(); // string("127.0.0.1")
+```
+
 ## Detecting Address Types
 
 ### Link Local

--- a/docs/10-api.md
+++ b/docs/10-api.md
@@ -1,49 +1,54 @@
 # API Reference
 
-| Method                                | Returns              | IPv4 | IPv6 | Multi |
-|---------------------------------------|----------------------|------|------|-------|
-| `factory(string $ip, [$strategy])`    | Static `IpInterface` | ✓    | ✓    | ✓     |
-| `getBinary()`                         | `string`             | ✓    | ✓    | ✓     |
-| `getOctets()`                         | `list<int>`          | ✓    | ✓    | ✓     |
-| `toString()`                          | `string`             | ✓    | ✓    | ✓     |
-| `jsonSerialize()`                     | `string`             | ✓    | ✓    | ✓     |
-| `toIntegerString()`                   | `string`             | ✓    | ✓    | ✓     |
-| `toHexString()`                       | `string`             | ✓    | ✓    | ✓     |
-| `equals(IpInterface $ip)`             | `bool`               | ✓    | ✓    | ✓     |
-| `getVersion()`                        | `int`                | ✓    | ✓    | ✓     |
-| `isVersion(int $version)`             | `bool`               | ✓    | ✓    | ✓     |
-| `isVersion4()`                        | `bool`               | ✓    | ✓    | ✓     |
-| `isVersion6()`                        | `bool`               | ✓    | ✓    | ✓     |
-| `getNetworkIp(int $cidr)`             | Static `IpInterface` | ✓    | ✓    | ✓     |
-| `getBroadcastIp(int $cidr)`           | Static `IpInterface` | ✓    | ✓    | ✓     |
-| `next()`                              | Static `IpInterface` | ✓    | ✓    | ✓     |
-| `previous()`                          | Static `IpInterface` | ✓    | ✓    | ✓     |
-| `offset(int $offset)`                 | Static `IpInterface` | ✓    | ✓    | ✓     |
-| `inRange(IpInterface $ip, int $cidr)` | `bool`               | ✓    | ✓    | ✓     |
-| `getCommonCidr(IpInterface $ip)`      | `int`                | ✓    | ✓    | ✓     |
-| `isMapped()`                          | `bool`               | ✓    | ✓    | ✓     |
-| `isDerived()`                         | `bool`               | ✓    | ✓    | ✓     |
-| `isCompatible()`                      | `bool`               | ✓    | ✓    | ✓     |
-| `isEmbedded()`                        | `bool`               | ✓    | ✓    | ✓     |
-| `isLinkLocal()`                       | `bool`               | ✓    | ✓    | ✓     |
-| `isLoopback()`                        | `bool`               | ✓    | ✓    | ✓     |
-| `isMulticast()`                       | `bool`               | ✓    | ✓    | ✓     |
-| `isPrivateUse()`                      | `bool`               | ✓    | ✓    | ✓     |
-| `isUnspecified()`                     | `bool`               | ✓    | ✓    | ✓     |
-| `isBenchmarking()`                    | `bool`               | ✓    | ✓    | ✓     |
-| `isDocumentation()`                   | `bool`               | ✓    | ✓    | ✓     |
-| `isGloballyReachable()`               | `bool`               | ✓    | ✓    | ✓     |
-| `isBroadcast()`                       | `bool`               | ✓    |      | ✓     |
-| `isShared()`                          | `bool`               | ✓    |      | ✓     |
-| `isFutureReserved()`                  | `bool`               | ✓    |      | ✓     |
-| `getDotAddress()`                     | `string`             | ✓    |      | ✓     |
-| `toInteger()`                         | `int`                | ✓    |      | ✓     |
-| `getCompactedAddress()`               | `string`             |      | ✓    | ✓     |
-| `getExpandedAddress()`                | `string`             |      | ✓    | ✓     |
-| `getCompactedAddress()`               | `string`             |      | ✓    | ✓     |
-| `getSegments()`                       | `list<int>`          |      | ✓    | ✓     |
-| `getMulticastScope()`                 | `?int`               |      | ✓    | ✓     |
-| `isUniqueLocal()`                     | `bool`               |      | ✓    | ✓     |
-| `isUnicast()`                         | `bool`               |      | ✓    | ✓     |
-| `isUnicastGlobal()`                   | `bool`               |      | ✓    | ✓     |
-| `getProtocolAppropriateAddress()`     | `string`             |      |      | ✓     |
+| Method                                     | Returns              | IPv4 | IPv6 | Multi |
+|--------------------------------------------|----------------------|------|------|-------|
+| `factory(string $ip, [$strategy])`         | Static `IpInterface` | ✓    | ✓    | ✓     |
+| `getBinary()`                              | `string`             | ✓    | ✓    | ✓     |
+| `getOctets()`                              | `list<int>`          | ✓    | ✓    | ✓     |
+| `toString()`                               | `string`             | ✓    | ✓    | ✓     |
+| `jsonSerialize()`                          | `string`             | ✓    | ✓    | ✓     |
+| `toIntegerString()`                        | `string`             | ✓    | ✓    | ✓     |
+| `toHexString()`                            | `string`             | ✓    | ✓    | ✓     |
+| `equals(IpInterface $ip)`                  | `bool`               | ✓    | ✓    | ✓     |
+| `getVersion()`                             | `int`                | ✓    | ✓    | ✓     |
+| `isVersion(int $version)`                  | `bool`               | ✓    | ✓    | ✓     |
+| `isVersion4()`                             | `bool`               | ✓    | ✓    | ✓     |
+| `isVersion6()`                             | `bool`               | ✓    | ✓    | ✓     |
+| `getNetworkIp(int $cidr)`                  | Static `IpInterface` | ✓    | ✓    | ✓     |
+| `getBroadcastIp(int $cidr)`                | Static `IpInterface` | ✓    | ✓    | ✓     |
+| `next()`                                   | Static `IpInterface` | ✓    | ✓    | ✓     |
+| `previous()`                               | Static `IpInterface` | ✓    | ✓    | ✓     |
+| `offset(int $offset)`                      | Static `IpInterface` | ✓    | ✓    | ✓     |
+| `inRange(IpInterface $ip, int $cidr)`      | `bool`               | ✓    | ✓    | ✓     |
+| `getCommonCidr(IpInterface $ip)`           | `int`                | ✓    | ✓    | ✓     |
+| `isMapped()`                               | `bool`               | ✓    | ✓    | ✓     |
+| `isDerived()`                              | `bool`               | ✓    | ✓    | ✓     |
+| `isCompatible()`                           | `bool`               | ✓    | ✓    | ✓     |
+| `isEmbedded()`                             | `bool`               | ✓    | ✓    | ✓     |
+| `isLinkLocal()`                            | `bool`               | ✓    | ✓    | ✓     |
+| `isLoopback()`                             | `bool`               | ✓    | ✓    | ✓     |
+| `isMulticast()`                            | `bool`               | ✓    | ✓    | ✓     |
+| `isPrivateUse()`                           | `bool`               | ✓    | ✓    | ✓     |
+| `isUnspecified()`                          | `bool`               | ✓    | ✓    | ✓     |
+| `isBenchmarking()`                         | `bool`               | ✓    | ✓    | ✓     |
+| `isDocumentation()`                        | `bool`               | ✓    | ✓    | ✓     |
+| `isGloballyReachable()`                    | `bool`               | ✓    | ✓    | ✓     |
+| `isBroadcast()`                            | `bool`               | ✓    |      | ✓     |
+| `isShared()`                               | `bool`               | ✓    |      | ✓     |
+| `isFutureReserved()`                       | `bool`               | ✓    |      | ✓     |
+| `getDotAddress()`                          | `string`             | ✓    |      | ✓     |
+| `toInteger()`                              | `int`                | ✓    |      | ✓     |
+| `getCompactedAddress()`                    | `string`             |      | ✓    | ✓     |
+| `getExpandedAddress()`                     | `string`             |      | ✓    | ✓     |
+| `getCompactedAddress()`                    | `string`             |      | ✓    | ✓     |
+| `getSegments()`                            | `list<int>`          |      | ✓    | ✓     |
+| `getMulticastScope()`                      | `?int`               |      | ✓    | ✓     |
+| `isUniqueLocal()`                          | `bool`               |      | ✓    | ✓     |
+| `isUnicast()`                              | `bool`               |      | ✓    | ✓     |
+| `isUnicastGlobal()`                        | `bool`               |      | ✓    | ✓     |
+| `isEmbeddedAccordingToStrategy($strategy)` | `bool`               |      | ✓    | ✓     |
+| `isNat64WellKnown()`                       | `bool`               |      | ✓    | ✓     |
+| `isNat64LocalUse()`                        | `bool`               |      | ✓    | ✓     |
+| `isTeredo()`                               | `bool`               |      | ✓    | ✓     |
+| `getEmbeddedIp([$strategy])`               | `IPv4`               |      | ✓    | ✓     |
+| `getProtocolAppropriateAddress()`          | `string`             |      |      | ✓     |

--- a/src/AbstractIP.php
+++ b/src/AbstractIP.php
@@ -191,16 +191,19 @@ abstract class AbstractIP implements IpInterface
         return $commonCidr;
     }
 
+    /** @not-deprecated IpInterface deprecated in favour of Contracts\StrategyDetectionInterface. */
     public function isMapped(): bool
     {
         return (new Strategy\Mapped())->isEmbedded($this->getBinary());
     }
 
+    /** @not-deprecated IpInterface deprecated in favour of Contracts\StrategyDetectionInterface. */
     public function isDerived(): bool
     {
         return (new Strategy\Derived())->isEmbedded($this->getBinary());
     }
 
+    /** @not-deprecated IpInterface deprecated in favour of Contracts\StrategyDetectionInterface. */
     public function isCompatible(): bool
     {
         return (new Strategy\Compatible())->isEmbedded($this->getBinary());

--- a/src/AbstractIP.php
+++ b/src/AbstractIP.php
@@ -191,22 +191,19 @@ abstract class AbstractIP implements IpInterface
         return $commonCidr;
     }
 
-    /** @not-deprecated IpInterface deprecated in favour of Contracts\StrategyDetectionInterface. */
     public function isMapped(): bool
     {
-        return (new Strategy\Mapped())->isEmbedded($this->getBinary());
+        return false;
     }
 
-    /** @not-deprecated IpInterface deprecated in favour of Contracts\StrategyDetectionInterface. */
     public function isDerived(): bool
     {
-        return (new Strategy\Derived())->isEmbedded($this->getBinary());
+        return false;
     }
 
-    /** @not-deprecated IpInterface deprecated in favour of Contracts\StrategyDetectionInterface. */
     public function isCompatible(): bool
     {
-        return (new Strategy\Compatible())->isEmbedded($this->getBinary());
+        return false;
     }
 
     public function isEmbedded(): bool

--- a/src/Contracts/StrategyDetectionInterface.php
+++ b/src/Contracts/StrategyDetectionInterface.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Darsyn\IP\Contracts;
+
+use Darsyn\IP\Strategy\EmbeddingStrategyInterface;
+use Darsyn\IP\Version\IPv4;
+
+/**
+ * @experimental
+ */
+interface StrategyDetectionInterface
+{
+    /**
+     * Whether an IPv4 address is embedded within this address, according to
+     * the supplied embedding strategy.
+     *
+     * This is the generic form of the named detection predicates; any strategy
+     * implementation (including a user-defined one) can be tested against the
+     * address without constructing a new IP object around it.
+     */
+    public function isEmbeddedAccordingToStrategy(EmbeddingStrategyInterface $strategy): bool;
+
+    /**
+     * Whether the IP is an IPv4-mapped IPv6 address, according to
+     * RFC 4291 § 2.5.5.2 (eg, "::ffff:7f00:1").
+     */
+    public function isMapped(): bool;
+
+    /**
+     * Whether the IP is a 6to4-derived address, according to RFC 3056 § 2 (eg,
+     * "2002:7f00:1::").
+     */
+    public function isDerived(): bool;
+
+    /**
+     * Whether the IP is an IPv4-compatible IPv6 address, according to
+     * RFC 4291 § 2.5.5.1 (eg, `::7f00:1`); deprecated by that same RFC.
+     */
+    public function isCompatible(): bool;
+
+    /**
+     * Whether the IP is a NAT64 address within the Well-Known Prefix
+     * `64:ff9b::/96`, according to RFC 6052 § 2.1 (eg, "64:ff9b::7f00:1").
+     */
+    public function isNat64WellKnown(): bool;
+
+    /**
+     * Whether the IP is a NAT64 address within the Local-use Prefix
+     * `64:ff9b:1::/48`, according to RFC 8215 § 4.
+     */
+    public function isNat64LocalUse(): bool;
+
+    /**
+     * Whether the IP is a Teredo tunnelling address within `2001::/32`,
+     * according to RFC 4380 § 4.
+     */
+    public function isTeredo(): bool;
+
+    /**
+     * Get the IPv4 address embedded in this address as an IPv4 instance.
+     *
+     * A null strategy falls back to the instance's own embedding strategy on
+     * Multi, or to the global default set via
+     * Multi::setDefaultEmbeddingStrategy() otherwise.
+     *
+     * @throws \Darsyn\IP\Exception\WrongVersionException when no IPv4 address
+     *         is embedded according to the strategy in effect.
+     */
+    public function getEmbeddedIp(?EmbeddingStrategyInterface $strategy = null): IPv4;
+}

--- a/src/IpInterface.php
+++ b/src/IpInterface.php
@@ -23,6 +23,8 @@ interface IpInterface extends ArithmeticInterface, ClassificationInterface, Comp
     /**
      * Whether the IP is an IPv4-mapped IPv6 address, according to
      * RFC 4291 § 2.5.5.2 (eg, "::ffff:7f00:1").
+     *
+     * @deprecated in favour of Contracts\StrategyDetectionInterface.
      */
     public function isMapped(): bool;
 
@@ -30,18 +32,24 @@ interface IpInterface extends ArithmeticInterface, ClassificationInterface, Comp
      * Whether the IP is a 6to4-derived address, according to RFC 3056 § 2. Any
      * address within the 6to4 block `2002::/16` (eg, "2002:7f00:1::"), all of
      * which embed an IPv4 address in bits 16-47.
+     *
+     * @deprecated in favour of Contracts\StrategyDetectionInterface.
      */
     public function isDerived(): bool;
 
     /**
      * Whether the IP is an IPv4-compatible IPv6 address, according to
      * RFC 4291 § 2.5.5.1 (eg, `::7f00:1`); deprecated by that same RFC.
+     *
+     * @deprecated in favour of Contracts\StrategyDetectionInterface.
      */
     public function isCompatible(): bool;
 
     /**
      * Whether the IP is an IPv4-embedded IPv6 address (according to the
      * embedding strategy used).
+     *
+     * @deprecated in favour of Contracts\StrategyDetectionInterface.
      */
     public function isEmbedded(): bool;
 

--- a/src/Version/IPv6.php
+++ b/src/Version/IPv6.php
@@ -8,6 +8,7 @@ use Darsyn\IP\AbstractIP;
 use Darsyn\IP\Exception;
 use Darsyn\IP\Strategy\EmbeddingStrategyInterface;
 use Darsyn\IP\Strategy\Nat64;
+use Darsyn\IP\Strategy\Teredo;
 use Darsyn\IP\Util\Binary;
 use Darsyn\IP\Util\MbString;
 
@@ -138,6 +139,34 @@ class IPv6 extends AbstractIP implements Version6Interface
         return new static($multi->getBinary());
     }
 
+    public function isEmbeddedAccordingToStrategy(EmbeddingStrategyInterface $strategy): bool
+    {
+        return $strategy->isEmbedded($this->getBinary());
+    }
+
+    public function isNat64WellKnown(): bool
+    {
+        return $this->isEmbeddedAccordingToStrategy(Nat64::wellKnown());
+    }
+
+    public function isNat64LocalUse(): bool
+    {
+        return $this->isEmbeddedAccordingToStrategy(Nat64::localUse());
+    }
+
+    public function isTeredo(): bool
+    {
+        return $this->isEmbeddedAccordingToStrategy(new Teredo());
+    }
+
+    public function getEmbeddedIp(?EmbeddingStrategyInterface $strategy = null): IPv4
+    {
+        // A null strategy falls back to Multi's global default; route through
+        // Multi (whose constructor resolves it) rather than widening the
+        // private default-strategy accessor.
+        return Multi::fromBinary($this->getBinary(), $strategy)->getEmbeddedIp();
+    }
+
     public function getExpandedAddress(): string
     {
         // Convert the 16-byte binary sequence into a hexadecimal-string
@@ -249,8 +278,8 @@ class IPv6 extends AbstractIP implements Version6Interface
         // § 3.1 forbids embedding non-global addresses within the Well-Known
         // Prefix, but a received address is not guaranteed to obey that, so
         // classify by the embedded address rather than trusting the prefix.
-        if (($wellKnown = Nat64::wellKnown())->isEmbedded($this->getBinary())) {
-            return (new IPv4($wellKnown->extract($this->getBinary())))->isGloballyReachable();
+        if ($this->isNat64WellKnown()) {
+            return $this->getEmbeddedIp(Nat64::wellKnown())->isGloballyReachable();
         }
         return $this->isUnicast()
             && !$this->isLoopback()
@@ -270,7 +299,7 @@ class IPv6 extends AbstractIP implements Version6Interface
             // 8215) as not globally reachable. Detection is by prefix membership
             // alone, covering every Network-Specific Prefix operators subdivide
             // the /48 into.
-            && !Nat64::localUse()->isEmbedded($this->getBinary())
+            && !$this->isNat64LocalUse()
             && !$this->isDocumentation()
             && !$this->isBenchmarking()
             && !$this->isIetfProtocolAssignment()

--- a/src/Version/IPv6.php
+++ b/src/Version/IPv6.php
@@ -6,9 +6,8 @@ namespace Darsyn\IP\Version;
 
 use Darsyn\IP\AbstractIP;
 use Darsyn\IP\Exception;
+use Darsyn\IP\Strategy;
 use Darsyn\IP\Strategy\EmbeddingStrategyInterface;
-use Darsyn\IP\Strategy\Nat64;
-use Darsyn\IP\Strategy\Teredo;
 use Darsyn\IP\Util\Binary;
 use Darsyn\IP\Util\MbString;
 
@@ -144,19 +143,37 @@ class IPv6 extends AbstractIP implements Version6Interface
         return $strategy->isEmbedded($this->getBinary());
     }
 
+    /** @not-deprecated IpInterface deprecated in favour of Contracts\StrategyDetectionInterface. */
+    public function isMapped(): bool
+    {
+        return $this->isEmbeddedAccordingToStrategy(new Strategy\Mapped());
+    }
+
+    /** @not-deprecated IpInterface deprecated in favour of Contracts\StrategyDetectionInterface. */
+    public function isDerived(): bool
+    {
+        return $this->isEmbeddedAccordingToStrategy(new Strategy\Derived());
+    }
+
+    /** @not-deprecated IpInterface deprecated in favour of Contracts\StrategyDetectionInterface. */
+    public function isCompatible(): bool
+    {
+        return $this->isEmbeddedAccordingToStrategy(new Strategy\Compatible());
+    }
+
     public function isNat64WellKnown(): bool
     {
-        return $this->isEmbeddedAccordingToStrategy(Nat64::wellKnown());
+        return $this->isEmbeddedAccordingToStrategy(Strategy\Nat64::wellKnown());
     }
 
     public function isNat64LocalUse(): bool
     {
-        return $this->isEmbeddedAccordingToStrategy(Nat64::localUse());
+        return $this->isEmbeddedAccordingToStrategy(Strategy\Nat64::localUse());
     }
 
     public function isTeredo(): bool
     {
-        return $this->isEmbeddedAccordingToStrategy(new Teredo());
+        return $this->isEmbeddedAccordingToStrategy(new Strategy\Teredo());
     }
 
     public function getEmbeddedIp(?EmbeddingStrategyInterface $strategy = null): IPv4
@@ -279,7 +296,7 @@ class IPv6 extends AbstractIP implements Version6Interface
         // Prefix, but a received address is not guaranteed to obey that, so
         // classify by the embedded address rather than trusting the prefix.
         if ($this->isNat64WellKnown()) {
-            return $this->getEmbeddedIp(Nat64::wellKnown())->isGloballyReachable();
+            return $this->getEmbeddedIp(Strategy\Nat64::wellKnown())->isGloballyReachable();
         }
         return $this->isUnicast()
             && !$this->isLoopback()

--- a/src/Version/Multi.php
+++ b/src/Version/Multi.php
@@ -329,12 +329,23 @@ class Multi extends IPv6 implements MultiVersionInterface
         return parent::getCommonCidr($ip);
     }
 
+    /** @not-deprecated IpInterface deprecated in favour of Contracts\StrategyDetectionInterface. */
     public function isEmbedded(): bool
     {
         if (null === $this->embedded) {
             $this->embedded = $this->embeddingStrategy->isEmbedded($this->getBinary());
         }
         return $this->embedded;
+    }
+
+    public function getEmbeddedIp(?EmbeddingStrategyInterface $strategy = null): IPv4
+    {
+        // An explicit strategy overrides the one attached to this instance.
+        $strategy = $strategy ?: $this->embeddingStrategy;
+        if (!$strategy->isEmbedded($this->getBinary())) {
+            throw new Exception\WrongVersionException(4, 6, (string) $this);
+        }
+        return IPv4::fromBinary($strategy->extract($this->getBinary()));
     }
 
     public function isLinkLocal(): bool

--- a/src/Version/MultiVersionInterface.php
+++ b/src/Version/MultiVersionInterface.php
@@ -15,6 +15,15 @@ interface MultiVersionInterface extends Version4Interface, Version6Interface
     public static function setDefaultEmbeddingStrategy(EmbeddingStrategyInterface $strategy): void;
 
     /**
+     * Whether an IPv4 address is embedded within this address, according to
+     * the embedding strategy in effect for this instance.
+     *
+     * @not-deprecated IpInterface deprecated in favour of
+     *                 Contracts\StrategyDetectionInterface
+     */
+    public function isEmbedded(): bool;
+
+    /**
      * Get Protocol-appropriate Address
      *
      * Converts an IP address into the smallest protocol notation it can;

--- a/src/Version/Version6Interface.php
+++ b/src/Version/Version6Interface.php
@@ -7,6 +7,7 @@ namespace Darsyn\IP\Version;
 use Darsyn\IP\Contracts\Classification6Interface;
 use Darsyn\IP\Contracts\FactoryInterface;
 use Darsyn\IP\Contracts\Output6Interface;
+use Darsyn\IP\Contracts\StrategyDetectionInterface;
 use Darsyn\IP\IpInterface;
 
-interface Version6Interface extends IpInterface, Classification6Interface, Output6Interface, FactoryInterface {}
+interface Version6Interface extends IpInterface, Classification6Interface, Output6Interface, FactoryInterface, StrategyDetectionInterface {}

--- a/tests/Version/IPv4Test.php
+++ b/tests/Version/IPv4Test.php
@@ -12,6 +12,7 @@ use Darsyn\IP\Contracts\Factory4Interface;
 use Darsyn\IP\Contracts\FactoryInterface;
 use Darsyn\IP\Contracts\Output4Interface;
 use Darsyn\IP\Contracts\OutputInterface;
+use Darsyn\IP\Contracts\StrategyDetectionInterface;
 use Darsyn\IP\Contracts\VersionIdentityInterface;
 use Darsyn\IP\Exception\InvalidBinaryException;
 use Darsyn\IP\Exception\InvalidCidrException;
@@ -52,6 +53,8 @@ class IPv4Test extends TestCase
         $this->assertInstanceOf(Classification4Interface::class, $ip);
         $this->assertInstanceOf(FactoryInterface::class, $ip);
         $this->assertInstanceOf(Factory4Interface::class, $ip);
+        // Strategy detection is a version 6 concept; IPv4 does not gain it.
+        $this->assertNotInstanceOf(StrategyDetectionInterface::class, $ip);
     }
 
     /**
@@ -387,6 +390,7 @@ class IPv4Test extends TestCase
 
     /**
      * @test
+     * @deprecated Retains coverage of the deprecated IpInterface::isEmbedded() on non-Multi classes.
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidProtocolIpAddresses()
      */
     #[PHPUnit\Test]

--- a/tests/Version/IPv4Test.php
+++ b/tests/Version/IPv4Test.php
@@ -354,6 +354,7 @@ class IPv4Test extends TestCase
 
     /**
      * @test
+     * @deprecated
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidProtocolIpAddresses()
      */
     #[PHPUnit\Test]
@@ -366,6 +367,7 @@ class IPv4Test extends TestCase
 
     /**
      * @test
+     * @deprecated
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidProtocolIpAddresses()
      */
     #[PHPUnit\Test]
@@ -378,6 +380,7 @@ class IPv4Test extends TestCase
 
     /**
      * @test
+     * @deprecated
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv4::getValidProtocolIpAddresses()
      */
     #[PHPUnit\Test]

--- a/tests/Version/IPv6Test.php
+++ b/tests/Version/IPv6Test.php
@@ -12,6 +12,7 @@ use Darsyn\IP\Contracts\Factory4Interface;
 use Darsyn\IP\Contracts\FactoryInterface;
 use Darsyn\IP\Contracts\Output6Interface;
 use Darsyn\IP\Contracts\OutputInterface;
+use Darsyn\IP\Contracts\StrategyDetectionInterface;
 use Darsyn\IP\Contracts\VersionIdentityInterface;
 use Darsyn\IP\Exception\InvalidBinaryException;
 use Darsyn\IP\Exception\InvalidCidrException;
@@ -21,9 +22,12 @@ use Darsyn\IP\Exception\WrongVersionException;
 use Darsyn\IP\Formatter\ConsistentFormatter;
 use Darsyn\IP\Formatter\NativeFormatter;
 use Darsyn\IP\IpInterface;
+use Darsyn\IP\Strategy\Derived;
 use Darsyn\IP\Strategy\Mapped;
 use Darsyn\IP\Tests\DataProvider\IPv4 as IPv4DataProvider;
 use Darsyn\IP\Tests\DataProvider\IPv6 as IPv6DataProvider;
+use Darsyn\IP\Tests\DataProvider\Strategy\Nat64 as Nat64DataProvider;
+use Darsyn\IP\Tests\DataProvider\Strategy\Teredo as TeredoDataProvider;
 use Darsyn\IP\Tests\Stub\StubFormatter;
 use Darsyn\IP\Tests\TestCase;
 use Darsyn\IP\Util\Binary;
@@ -55,6 +59,7 @@ class IPv6Test extends TestCase
         $this->assertInstanceOf(ClassificationInterface::class, $ip);
         $this->assertInstanceOf(Classification6Interface::class, $ip);
         $this->assertInstanceOf(FactoryInterface::class, $ip);
+        $this->assertInstanceOf(StrategyDetectionInterface::class, $ip);
         // fromInteger() is version 4 only; IPv6 deliberately does not gain it.
         $this->assertNotInstanceOf(Factory4Interface::class, $ip);
     }
@@ -452,6 +457,7 @@ class IPv6Test extends TestCase
 
     /**
      * @test
+     * @deprecated Retains coverage of the deprecated IpInterface::isEmbedded() on non-Multi classes.
      * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getValidProtocolIpAddresses()
      */
     #[PHPUnit\Test]
@@ -987,5 +993,108 @@ class IPv6Test extends TestCase
     public function testToHexStringRoundTripsWithFromHex(string $value, string $hex, string $expanded, string $compacted): void
     {
         $this->assertSame($value, IP::fromHex(IP::fromBinary($value)->toHexString())->getBinary());
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\IPv6::getMappedIpAddresses()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(IPv6DataProvider::class, 'getMappedIpAddresses')]
+    public function testIsEmbeddedAccordingToStrategy(string $value, bool $isMapped): void
+    {
+        $ip = IP::fromProtocol($value);
+        $this->assertSame($isMapped, $ip->isEmbeddedAccordingToStrategy(new Mapped()));
+        $this->assertSame($ip->isMapped(), $ip->isEmbeddedAccordingToStrategy(new Mapped()));
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getValidIpAddresses()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getValidIpAddresses')]
+    public function testIsNat64WellKnown(string $value, bool $embedded): void
+    {
+        $this->assertSame($embedded, IP::fromBinary($value)->isNat64WellKnown());
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getLocalUseSequences()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getLocalUseSequences')]
+    public function testIsNat64LocalUse(string $value, string $embedded): void
+    {
+        $this->assertTrue(IP::fromBinary($value)->isNat64LocalUse());
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getNonMatchingLocalUseSequences()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getNonMatchingLocalUseSequences')]
+    public function testIsNat64LocalUseReturnsFalseOutsidePrefix(string $value): void
+    {
+        $this->assertFalse(IP::fromBinary($value)->isNat64LocalUse());
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Teredo::getValidIpAddresses()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(TeredoDataProvider::class, 'getValidIpAddresses')]
+    public function testIsTeredo(string $value, bool $embedded): void
+    {
+        $this->assertSame($embedded, IP::fromBinary($value)->isTeredo());
+    }
+
+    /** @test */
+    #[PHPUnit\Test]
+    public function testGetEmbeddedIpWithDefaultStrategy(): void
+    {
+        $embedded = IP::fromProtocol('::ffff:12.34.56.78')->getEmbeddedIp();
+        $this->assertInstanceOf(IPv4::class, $embedded);
+        $this->assertSame('12.34.56.78', $embedded->getDotAddress());
+    }
+
+    /** @test */
+    #[PHPUnit\Test]
+    public function testGetEmbeddedIpThrowsWhenNotEmbedded(): void
+    {
+        $ip = IP::fromProtocol('2001:db8::1');
+        $this->expectException(WrongVersionException::class);
+        $ip->getEmbeddedIp();
+    }
+
+    /** @test */
+    #[PHPUnit\Test]
+    public function testGetEmbeddedIpWithExplicitStrategy(): void
+    {
+        $ip = IP::fromProtocol('2002:c22:384e::');
+        $this->assertSame('12.34.56.78', $ip->getEmbeddedIp(new Derived())->getDotAddress());
+    }
+
+    /** @test */
+    #[PHPUnit\Test]
+    public function testGetEmbeddedIpThrowsWhenNotEmbeddedAccordingToDefaultStrategy(): void
+    {
+        // A 6to4-derived form embeds nothing according to the Mapped default.
+        $ip = IP::fromProtocol('2002:c22:384e::');
+        $this->expectException(WrongVersionException::class);
+        $ip->getEmbeddedIp();
+    }
+
+    /** @test */
+    #[PHPUnit\Test]
+    public function testGetEmbeddedIpRoundTripsWithFromEmbedded(): void
+    {
+        $this->assertSame(
+            IPv4::fromProtocol('12.34.56.78')->getBinary(),
+            IP::fromEmbedded('12.34.56.78', new Mapped())->getEmbeddedIp(new Mapped())->getBinary()
+        );
     }
 }

--- a/tests/Version/MultiTest.php
+++ b/tests/Version/MultiTest.php
@@ -14,6 +14,7 @@ use Darsyn\IP\Contracts\FactoryInterface;
 use Darsyn\IP\Contracts\Output4Interface;
 use Darsyn\IP\Contracts\Output6Interface;
 use Darsyn\IP\Contracts\OutputInterface;
+use Darsyn\IP\Contracts\StrategyDetectionInterface;
 use Darsyn\IP\Contracts\VersionIdentityInterface;
 use Darsyn\IP\Exception\InvalidBinaryException;
 use Darsyn\IP\Exception\InvalidIpAddressException;
@@ -25,6 +26,8 @@ use Darsyn\IP\Strategy;
 use Darsyn\IP\Tests\DataProvider\IPv4 as IPv4DataProvider;
 use Darsyn\IP\Tests\DataProvider\IPv6 as IPv6DataProvider;
 use Darsyn\IP\Tests\DataProvider\Multi as MultiDataProvider;
+use Darsyn\IP\Tests\DataProvider\Strategy\Nat64 as Nat64DataProvider;
+use Darsyn\IP\Tests\DataProvider\Strategy\Teredo as TeredoDataProvider;
 use Darsyn\IP\Tests\Stub\StubFormatter;
 use Darsyn\IP\Tests\TestCase;
 use Darsyn\IP\Util\Binary;
@@ -68,6 +71,8 @@ class MultiTest extends TestCase
         $this->assertInstanceOf(Classification6Interface::class, $ip);
         $this->assertInstanceOf(FactoryInterface::class, $ip);
         $this->assertInstanceOf(Factory4Interface::class, $ip);
+        $this->assertInstanceOf(StrategyDetectionInterface::class, $ip);
+        $this->assertInstanceOf(MultiVersionInterface::class, $ip);
     }
 
     /**
@@ -1076,5 +1081,89 @@ class MultiTest extends TestCase
     {
         $this->expectException(InvalidIpAddressException::class);
         IP::fromIntegerString($value);
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getValidProtocolIpVersion4Addresses()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(MultiDataProvider::class, 'getValidProtocolIpVersion4Addresses')]
+    public function testIsEmbeddedForVersion4Addresses(string $value, string $hex, string $expanded, string $compacted, ?string $dot): void
+    {
+        $this->assertTrue(IP::fromProtocol($value)->isEmbedded());
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Multi::getValidProtocolIpVersion6Addresses()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(MultiDataProvider::class, 'getValidProtocolIpVersion6Addresses')]
+    public function testIsEmbeddedForVersion6Addresses(string $value, string $hex, string $expanded, string $compacted, ?string $dot): void
+    {
+        $this->assertFalse(IP::fromProtocol($value)->isEmbedded());
+    }
+
+    /** @test */
+    #[PHPUnit\Test]
+    public function testGetEmbeddedIpUsesInstanceStrategy(): void
+    {
+        $ip = IP::fromProtocol('12.34.56.78', new Strategy\Derived());
+        $embedded = $ip->getEmbeddedIp();
+        $this->assertInstanceOf(IPv4::class, $embedded);
+        $this->assertSame('12.34.56.78', $embedded->getDotAddress());
+    }
+
+    /** @test */
+    #[PHPUnit\Test]
+    public function testGetEmbeddedIpWithExplicitStrategyOverridesInstanceStrategy(): void
+    {
+        $ip = IP::fromProtocol('12.34.56.78', new Strategy\Derived());
+        $this->expectException(WrongVersionException::class);
+        $ip->getEmbeddedIp(new Strategy\Mapped());
+    }
+
+    /** @test */
+    #[PHPUnit\Test]
+    public function testGetEmbeddedIpThrowsForNonEmbeddedAddress(): void
+    {
+        $ip = IP::fromProtocol('2001:db8::1');
+        $this->expectException(WrongVersionException::class);
+        $ip->getEmbeddedIp();
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Teredo::getValidSequences()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(TeredoDataProvider::class, 'getValidSequences')]
+    public function testGetEmbeddedIpExtractsTeredoClientAddress(string $value, string $embedded): void
+    {
+        $ip = IP::fromBinary($value, new Strategy\Teredo());
+        $this->assertSame($embedded, $ip->getEmbeddedIp()->getBinary());
+    }
+
+    /**
+     * @test
+     * @dataProvider \Darsyn\IP\Tests\DataProvider\Strategy\Nat64::getValidSequences()
+     */
+    #[PHPUnit\Test]
+    #[PHPUnit\DataProviderExternal(Nat64DataProvider::class, 'getValidSequences')]
+    public function testGetEmbeddedIpExtractsNat64WellKnownAddress(string $value, string $embedded): void
+    {
+        $ip = IP::fromBinary($value, Strategy\Nat64::wellKnown());
+        $this->assertSame($embedded, $ip->getEmbeddedIp()->getBinary());
+    }
+
+    /** @test */
+    #[PHPUnit\Test]
+    public function testGetEmbeddedIpOnIPv6RespectsGlobalDefaultStrategy(): void
+    {
+        $ip = IPv6::fromProtocol('2002:c22:384e::');
+        IP::setDefaultEmbeddingStrategy(new Strategy\Derived());
+        $this->assertSame('12.34.56.78', $ip->getEmbeddedIp()->getDotAddress());
+        IP::setDefaultEmbeddingStrategy(new Strategy\Mapped());
     }
 }


### PR DESCRIPTION
The `IpInterface` declarations are deprecated in favour of `StrategyDetectionInterface`