### PR TITLE
Rename the whole-value output methods to `to*` conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## `6.x`
 
+- Rename the whole-value output methods to `to*` (conversions), keeping `get*`
+  for component and property accessors. Keep the `get*` spellings as deprecated
+  aliases; `getBinary()` is exempt as the accessor of the canonical state.
 - Detect embedding strategies via the new `Contracts\StrategyDetectionInterface`
   deprecating the old `IpInterface::isEmbedded()` and associated methods.
 - Convert IP addresses to and from integers: `fromInteger()`/`toInteger()` via
@@ -25,10 +28,12 @@
   `fromProtocol()`/`fromBinary()`.
 - Introduce `@experimental` capability interfaces under `Darsyn\IP\Contracts\`.
   Their shape may change before `7.0`, but remains backwards compatible for `6.x`
-- Allow overriding the global formatter per call by passing a
-  `Formatter\ProtocolFormatterInterface` as the first argument to
-  `IPv4::getDotAddress()`, `IPv6::getCompactedAddress()`,
-  `Multi::getDotAddress()` and `Multi::getProtocolAppropriateAddress()`.
+- Allow overriding the global formatter per call via an optional
+  `Formatter\ProtocolFormatterInterface` parameter on `toDotAddress()`,
+  `toCompactedAddress()` and `toProtocolAppropriateAddress()` (deprecated
+  `get*` aliases accept the same argument, but any other value triggers a
+  deprecation notice and falls back to the global formatter instead of
+  throwing a `TypeError`).
 - Move CIDR mask generation from the protected `AbstractIP::generateBinaryMask()`
   to the public static `Util\Binary::mask()`.
 - Performance: compute network masks (`getNetworkIp()` / `getBroadcastIp()`)

--- a/docs/03-overview.md
+++ b/docs/03-overview.md
@@ -172,8 +172,8 @@ Human-readable format comes in 3 flavours:
 
 ### Dot Address
 
-`getDotAddress()` is only available for `IPv4` and `Multi` classes. Calling
-`getDotAddress()` on an instance of `Multi` that contains a version 6 address
+`toDotAddress()` is only available for `IPv4` and `Multi` classes. Calling
+`toDotAddress()` on an instance of `Multi` that contains a version 6 address
 will result in a `WrongVersionException` being thrown.
 
 ```php
@@ -184,7 +184,7 @@ use Darsyn\IP\Exception;
 $ip = IP::factory('127.0.0.1');
 
 try {
-    echo $ip->getDotAddress(); // string("127.0.0.1")
+    echo $ip->toDotAddress(); // string("127.0.0.1")
 } catch (Exception\WrongVersionException $e) {
     echo 'Cannot convert a version 6 address to dot-notation!';
 }
@@ -192,8 +192,8 @@ try {
 
 ### Compacted Address
 
-`getCompactedAddress()` is only available for `IPv6` and `Multi` classes.
-Calling `getCompactedAddress()` on an instance of `Multi` that contains a
+`toCompactedAddress()` is only available for `IPv6` and `Multi` classes.
+Calling `toCompactedAddress()` on an instance of `Multi` that contains a
 version 4 address will result in the IP address being converted to a version 6
 address according to the embedding strategy.
 
@@ -202,13 +202,13 @@ address according to the embedding strategy.
 use Darsyn\IP\Version\Multi as IP;
 
 $ip = IP::factory('127.0.0.1');
-echo $ip->getCompactedAddress(); // string("::ffff:7f00:1")
+echo $ip->toCompactedAddress(); // string("::ffff:7f00:1")
 ```
 
 ### Expanded Address
 
-`getExpandedAddress()` is only available for `IPv6` and `Multi` classes. Calling
-`getExpandedAddress()` on an instance of `Multi` that contains a version 4
+`toExpandedAddress()` is only available for `IPv6` and `Multi` classes. Calling
+`toExpandedAddress()` on an instance of `Multi` that contains a version 4
 address will result in the IP address being converted to a version 6 address
 according to the embedding strategy.
 
@@ -217,12 +217,12 @@ according to the embedding strategy.
 use Darsyn\IP\Version\Multi as IP;
 
 $ip = IP::factory('127.0.0.1');
-$ip->getExpandedAddress(); // string("0000:0000:0000:0000:0000:ffff:7f00:0001")
+$ip->toExpandedAddress(); // string("0000:0000:0000:0000:0000:ffff:7f00:0001")
 ```
 
 ### Protocol Appropriate Address
 
-`getProtocolAppropriateAddress()` is only available for the `Multi` class. If
+`toProtocolAppropriateAddress()` is only available for the `Multi` class. If
 the instance of `Multi` contains a version 4 address, it will be returned in
 dot notation, otherwise it returns a compacted version 6 address.
 
@@ -231,7 +231,7 @@ dot notation, otherwise it returns a compacted version 6 address.
 use Darsyn\IP\Version\Multi as IP;
 
 $ip = IP::factory('::ffff:7f00:1');
-$ip->getProtocolAppropriateAddress(); // string("127.0.0.1")
+$ip->toProtocolAppropriateAddress(); // string("127.0.0.1")
 ```
 
 ### Binary
@@ -337,11 +337,11 @@ so `__toString()` is implemented independently (deferring to `toString()`). The
 returned string is in protocol-appropriate notation and can be re-parsed via
 `fromProtocol()`.
 
-- String casting the `IPv4` class is the equivalent of `$ip->getDotAddress()`.
+- String casting the `IPv4` class is the equivalent of `$ip->toDotAddress()`.
 - String casting the `IPv6` class is the equivalent of
-  `$ip->getCompactedAddress()`.
+  `$ip->toCompactedAddress()`.
 - String casting the `Multi` class is the equivalent of
-  `$ip->getProtocolAppropriateAddress()`.
+  `$ip->toProtocolAppropriateAddress()`.
 
 ```php
 <?php

--- a/docs/04-helpers.md
+++ b/docs/04-helpers.md
@@ -115,7 +115,7 @@ use Darsyn\IP\Version\Multi as IP;
 $ip = IP::factory('12.34.56.78');
 // Get the network address of an IP address given a subnet mask.
 $networkIp = $ip->getNetworkIp(19);
-$networkIp->getProtocolAppropriateAddress(); // string("12.34.32.0")
+$networkIp->toProtocolAppropriateAddress(); // string("12.34.32.0")
 ```
 
 ### Broadcast IP
@@ -133,7 +133,7 @@ use Darsyn\IP\Version\Multi as IP;
 $ip = IP::factory('12.34.56.78');
 // Get the broadcast address of an IP address given a subnet mask.
 $broadcastIp = $ip->getBroadcastIp(19);
-$broadcastIp->getProtocolAppropriateAddress(); // string("12.34.63.255")
+$broadcastIp->toProtocolAppropriateAddress(); // string("12.34.63.255")
 ```
 
 ### Is IP in Range?
@@ -188,10 +188,10 @@ use Darsyn\IP\Version\IPv4 as IP;
 
 $ip = IP::fromProtocol('12.34.56.78');
 // Step forwards or backwards within the address space.
-$ip->next()->getDotAddress();      // string("12.34.56.79")
-$ip->previous()->getDotAddress();  // string("12.34.56.77")
-$ip->offset(256)->getDotAddress(); // string("12.34.57.78")
-$ip->offset(-79)->getDotAddress(); // string("12.34.55.255")
+$ip->next()->toDotAddress();      // string("12.34.56.79")
+$ip->previous()->toDotAddress();  // string("12.34.56.77")
+$ip->offset(256)->toDotAddress(); // string("12.34.57.78")
+$ip->offset(-79)->toDotAddress(); // string("12.34.55.255")
 ```
 
 ## `IPv6` vs `Multi`?
@@ -234,13 +234,13 @@ use Darsyn\IP\Version\Ipv6;
 // Strategy is optional; defaults to Mapped unless
 // Multi::setDefaultEmbeddingStrategy() called previously.
 $ip = IPv6::fromEmbedded('127.0.0.1', new Mapped);
-$ip->getCompactedAddress(); // string("::ffff:7f00:1")
+$ip->toCompactedAddress(); // string("::ffff:7f00:1")
 
 try {
-    $ip->getDotAddress();
+    $ip->toDotAddress();
 } catch (\Error $e) {
     // IPv6 addresses are not considered IPv4 addresses and
-    // therefore do not have the method getDotAddress().
+    // therefore do not have the method toDotAddress().
 }
 ```
 

--- a/docs/05-strategies.md
+++ b/docs/05-strategies.md
@@ -158,10 +158,10 @@ use Darsyn\IP\Version\Multi as IP;
 $strategy = new Composite(new Mapped, Nat64::wellKnown());
 
 // Addresses embedded under either scheme are recognised as version 4.
-IP::factory('::ffff:7f00:1', $strategy)->getDotAddress();   // string("127.0.0.1")
-IP::factory('64:ff9b::7f00:1', $strategy)->getDotAddress(); // string("127.0.0.1")
+IP::factory('::ffff:7f00:1', $strategy)->toDotAddress();   // string("127.0.0.1")
+IP::factory('64:ff9b::7f00:1', $strategy)->toDotAddress(); // string("127.0.0.1")
 
 // But only the first strategy (here, Mapped) is ever used to pack a version 4
 // address into version 6.
-IP::factory('127.0.0.1', $strategy)->getCompactedAddress(); // string("::ffff:7f00:1")
+IP::factory('127.0.0.1', $strategy)->toCompactedAddress(); // string("::ffff:7f00:1")
 ```

--- a/docs/06-formatters.md
+++ b/docs/06-formatters.md
@@ -20,17 +20,17 @@ use Darsyn\IP\Version\Multi as IP;
 
 IP::setProtocolFormatter(new NativeFormatter);
 $ip = IP::factory('::ffff:c22:384e');
-$ip->getCompactedAddress(); // string("::ffff:12.34.56.78")
+$ip->toCompactedAddress(); // string("::ffff:12.34.56.78")
 ```
 
 ## Per-call formatter
 `setProtocolFormatter()` changes the formatter globally for every IP object, the
 formatting methods therefore accept an optional formatter as their
 first argument, overriding the global formatter for that call alone:
-- `Darsyn\IP\Version\IPv4::getDotAddress()`
-- `Darsyn\IP\Version\IPv6::getCompactedAddress()`
-- `Darsyn\IP\Version\Multi::getDotAddress()`
-- `Darsyn\IP\Version\Multi::getProtocolAppropriateAddress()`
+- `Darsyn\IP\Version\IPv4::toDotAddress()`
+- `Darsyn\IP\Version\IPv6::toCompactedAddress()`
+- `Darsyn\IP\Version\Multi::toDotAddress()`
+- `Darsyn\IP\Version\Multi::toProtocolAppropriateAddress()`
 
 ```php
 <?php
@@ -41,10 +41,12 @@ use Darsyn\IP\Version\IPv6 as IP;
 IP::setProtocolFormatter(new ConsistentFormatter());
 $ip = IP::factory('::ffff:c22:384e');
 
-$ip->getCompactedAddress();                      // string("::ffff:c22:384e")
-$ip->getCompactedAddress(new NativeFormatter);   // string("::ffff:12.34.56.78")
-$ip->getCompactedAddress();                      // string("::ffff:c22:384e")
+$ip->toCompactedAddress();                      // string("::ffff:c22:384e")
+$ip->toCompactedAddress(new NativeFormatter);   // string("::ffff:12.34.56.78")
+$ip->toCompactedAddress();                      // string("::ffff:c22:384e")
 ```
 
-Passing any value that does not implement
-`Darsyn\IP\Formatter\ProtocolFormatterInterface` will trigger a deprecation notice and fall back to the global formatter.
+These methods declare the parameter as a nullable
+`Darsyn\IP\Formatter\ProtocolFormatterInterface`, so passing any other value
+throws a `TypeError`. Their deprecated `get*` counterparts accept the same
+argument but trigger a deprecation notice and fall back to the global formatter.

--- a/docs/07-types.md
+++ b/docs/07-types.md
@@ -139,7 +139,7 @@ embedding strategy on `Multi`, or to the global default set via
 use Darsyn\IP\Version\Multi as IP;
 
 $ip = IP::fromProtocol('::ffff:7f00:1');
-$ip->getEmbeddedIp()->getDotAddress(); // string("127.0.0.1")
+$ip->getEmbeddedIp()->toDotAddress(); // string("127.0.0.1")
 ```
 
 ## Detecting Address Types

--- a/src/Contracts/Output4Interface.php
+++ b/src/Contracts/Output4Interface.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Darsyn\IP\Contracts;
 
+use Darsyn\IP\Formatter\ProtocolFormatterInterface;
+
 /**
  * @experimental
  */
 interface Output4Interface extends OutputInterface
 {
     /**
-     * Get Dot Address
+     * Convert to Dot Address Notation
      *
      * Convert an IP into an IPv4 dot-notation address string
      * This method will NOT work with IPv6 addresses.
@@ -18,10 +20,10 @@ interface Output4Interface extends OutputInterface
      * @throws \Darsyn\IP\Exception\IpException
      * @throws \Darsyn\IP\Exception\WrongVersionException
      */
-    public function getDotAddress(): string;
+    public function toDotAddress(?ProtocolFormatterInterface $formatter = null): string;
 
     /**
-     * Get Integer
+     * Convert to Integer
      *
      * Convert an IP into its unsigned 32-bit integer value, between 0 and
      * 4294967295. This method will NOT work with IPv6 addresses.

--- a/src/Contracts/Output6Interface.php
+++ b/src/Contracts/Output6Interface.php
@@ -4,30 +4,32 @@ declare(strict_types=1);
 
 namespace Darsyn\IP\Contracts;
 
+use Darsyn\IP\Formatter\ProtocolFormatterInterface;
+
 /**
  * @experimental
  */
 interface Output6Interface extends OutputInterface
 {
     /**
-     * Get Compacted Address
+     * Convert to Compacted Address Notation
      *
      * Converts an IP (regardless of version) into a compacted IPv6 address
      * (including double-colons if appropriate).
      *
      * @throws \Darsyn\IP\Exception\IpException
      */
-    public function getCompactedAddress(): string;
+    public function toCompactedAddress(?ProtocolFormatterInterface $formatter = null): string;
 
     /**
-     * Get Expanded Address
+     * Convert to Expanded Address Notation
      *
      * Converts an IP (regardless of version) address into a full IPv6 address
      * (no double colons).
      *
      * @throws \Darsyn\IP\Exception\IpException
      */
-    public function getExpandedAddress(): string;
+    public function toExpandedAddress(): string;
 
     /**
      * Get the IP address as an array of the eight 16-bit segments (hextets).

--- a/src/Version/IPv4.php
+++ b/src/Version/IPv4.php
@@ -6,6 +6,7 @@ namespace Darsyn\IP\Version;
 
 use Darsyn\IP\AbstractIP;
 use Darsyn\IP\Exception;
+use Darsyn\IP\Formatter\ProtocolFormatterInterface;
 use Darsyn\IP\Util\Binary;
 use Darsyn\IP\Util\MbString;
 
@@ -160,13 +161,19 @@ class IPv4 extends AbstractIP implements Version4Interface
         return null !== static::tryFromProtocol($ip);
     }
 
-    public function getDotAddress(/* ?ProtocolFormatterInterface $formatter = null */): string
+    public function toDotAddress(?ProtocolFormatterInterface $formatter = null): string
     {
         try {
-            return self::resolveProtocolFormatter(\func_get_args())->ntop($this->getBinary());
+            return ($formatter ?? self::getProtocolFormatter())->ntop($this->getBinary());
         } catch (Exception\Formatter\FormatException $e) {
             throw new Exception\IpException('An unknown error occurred internally.', 0, $e);
         }
+    }
+
+    /** @deprecated Use toDotAddress() instead. */
+    public function getDotAddress(/* ?ProtocolFormatterInterface $formatter = null */): string
+    {
+        return $this->toDotAddress(self::resolveProtocolFormatter(\func_get_args()));
     }
 
     /** @return int<0, 4294967295> */
@@ -302,7 +309,7 @@ class IPv4 extends AbstractIP implements Version4Interface
 
     public function toString(): string
     {
-        return $this->getDotAddress();
+        return $this->toDotAddress();
     }
 
     public function __toString(): string

--- a/src/Version/IPv6.php
+++ b/src/Version/IPv6.php
@@ -6,6 +6,7 @@ namespace Darsyn\IP\Version;
 
 use Darsyn\IP\AbstractIP;
 use Darsyn\IP\Exception;
+use Darsyn\IP\Formatter\ProtocolFormatterInterface;
 use Darsyn\IP\Strategy;
 use Darsyn\IP\Strategy\EmbeddingStrategyInterface;
 use Darsyn\IP\Util\Binary;
@@ -193,7 +194,7 @@ class IPv6 extends AbstractIP implements Version6Interface
         return Multi::fromBinary($this->getBinary(), $strategy)->getEmbeddedIp();
     }
 
-    public function getExpandedAddress(): string
+    public function toExpandedAddress(): string
     {
         // Convert the 16-byte binary sequence into a hexadecimal-string
         // representation, insert a colon between every block of 4 characters,
@@ -202,13 +203,25 @@ class IPv6 extends AbstractIP implements Version6Interface
         return MbString::subString(\is_string($expanded) ? $expanded : '', 0, -1);
     }
 
-    public function getCompactedAddress(/* ?ProtocolFormatterInterface $formatter = null */): string
+    /** @deprecated Use toExpandedAddress() instead. */
+    public function getExpandedAddress(): string
+    {
+        return $this->toExpandedAddress();
+    }
+
+    public function toCompactedAddress(?ProtocolFormatterInterface $formatter = null): string
     {
         try {
-            return self::resolveProtocolFormatter(\func_get_args())->ntop($this->getBinary());
+            return ($formatter ?? self::getProtocolFormatter())->ntop($this->getBinary());
         } catch (Exception\Formatter\FormatException $e) {
             throw new Exception\IpException('An unknown error occurred internally.', 0, $e);
         }
+    }
+
+    /** @deprecated Use toCompactedAddress() instead. */
+    public function getCompactedAddress(/* ?ProtocolFormatterInterface $formatter = null */): string
+    {
+        return $this->toCompactedAddress(self::resolveProtocolFormatter(\func_get_args()));
     }
 
     public function getSegments(): array
@@ -370,7 +383,7 @@ class IPv6 extends AbstractIP implements Version6Interface
 
     public function toString(): string
     {
-        return $this->getCompactedAddress();
+        return $this->toCompactedAddress();
     }
 
     public function __toString(): string

--- a/src/Version/Multi.php
+++ b/src/Version/Multi.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Darsyn\IP\Version;
 
 use Darsyn\IP\Exception;
+use Darsyn\IP\Formatter\ProtocolFormatterInterface;
 use Darsyn\IP\IpInterface;
 use Darsyn\IP\Strategy\CanonicalEmbeddingInterface;
 use Darsyn\IP\Strategy\EmbeddingStrategyInterface;
@@ -214,26 +215,28 @@ class Multi extends IPv6 implements MultiVersionInterface
         parent::__construct($ip);
     }
 
-    public function getProtocolAppropriateAddress(/* ?ProtocolFormatterInterface $formatter = null */): string
+    public function toProtocolAppropriateAddress(?ProtocolFormatterInterface $formatter = null): string
     {
         // If binary string contains an embedded IPv4 address, then extract it.
-        $ip = $this->isEmbedded()
-            ? $this->getShortBinary()
-            : $this->getBinary();
+        $ip = $this->isEmbedded() ? $this->getShortBinary() : $this->getBinary();
         // Render the IP address in the correct notation according to its
         // protocol (based on how long the binary string is).
-        return self::resolveProtocolFormatter(\func_get_args())->ntop($ip);
+        return ($formatter ?? self::getProtocolFormatter())->ntop($ip);
+    }
+
+    /** @deprecated Use toProtocolAppropriateAddress() instead. */
+    public function getProtocolAppropriateAddress(/* ?ProtocolFormatterInterface $formatter = null */): string
+    {
+        return $this->toProtocolAppropriateAddress(self::resolveProtocolFormatter(\func_get_args()));
     }
 
     /**
      * @throws \Darsyn\IP\Exception\WrongVersionException
      * @throws \Darsyn\IP\Exception\IpException
      */
-    public function getDotAddress(/* ?ProtocolFormatterInterface $formatter = null */): string
+    public function toDotAddress(?ProtocolFormatterInterface $formatter = null): string
     {
-        // Resolve the per-call formatter argument before the version check so a
-        // deprecated (non-formatter) argument is flagged regardless of embedded state.
-        $formatter = self::resolveProtocolFormatter(\func_get_args());
+        $formatter = $formatter ?? self::getProtocolFormatter();
         if ($this->isEmbedded()) {
             try {
                 return $formatter->ntop($this->getShortBinary());
@@ -242,6 +245,14 @@ class Multi extends IPv6 implements MultiVersionInterface
             }
         }
         throw new Exception\WrongVersionException(4, 6, (string) $this);
+    }
+
+    /** @deprecated Use toDotAddress() instead. */
+    public function getDotAddress(/* ?ProtocolFormatterInterface $formatter = null */): string
+    {
+        // Resolve the per-call formatter argument before the version check so a
+        // deprecated (non-formatter) argument is flagged regardless of embedded state.
+        return $this->toDotAddress(self::resolveProtocolFormatter(\func_get_args()));
     }
 
     /** @throws \Darsyn\IP\Exception\WrongVersionException */
@@ -496,7 +507,7 @@ class Multi extends IPv6 implements MultiVersionInterface
 
     public function toString(): string
     {
-        return $this->getProtocolAppropriateAddress();
+        return $this->toProtocolAppropriateAddress();
     }
 
     public function __toString(): string

--- a/src/Version/MultiVersionInterface.php
+++ b/src/Version/MultiVersionInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Darsyn\IP\Version;
 
+use Darsyn\IP\Formatter\ProtocolFormatterInterface;
 use Darsyn\IP\Strategy\EmbeddingStrategyInterface;
 
 interface MultiVersionInterface extends Version4Interface, Version6Interface
@@ -23,13 +24,16 @@ interface MultiVersionInterface extends Version4Interface, Version6Interface
      */
     public function isEmbedded(): bool;
 
+    /** @deprecated Use toProtocolAppropriateAddress() instead. */
+    public function getProtocolAppropriateAddress(): string;
+
     /**
-     * Get Protocol-appropriate Address
+     * Convert to Protocol-appropriate Address Notation
      *
      * Converts an IP address into the smallest protocol notation it can;
      * dot-notation for IPv4, and compacted (double colons) notation for IPv6.
      * Only IPv4 addresses according to the embedding strategy used will be
      * returned in dot-notation.
      */
-    public function getProtocolAppropriateAddress(): string;
+    public function toProtocolAppropriateAddress(?ProtocolFormatterInterface $formatter = null): string;
 }

--- a/src/Version/Version4Interface.php
+++ b/src/Version/Version4Interface.php
@@ -9,4 +9,8 @@ use Darsyn\IP\Contracts\Factory4Interface;
 use Darsyn\IP\Contracts\Output4Interface;
 use Darsyn\IP\IpInterface;
 
-interface Version4Interface extends IpInterface, Classification4Interface, Output4Interface, Factory4Interface {}
+interface Version4Interface extends IpInterface, Classification4Interface, Output4Interface, Factory4Interface
+{
+    /** @deprecated Use toDotAddress() instead. */
+    public function getDotAddress(/* ?ProtocolFormatterInterface $formatter = null */): string;
+}

--- a/src/Version/Version6Interface.php
+++ b/src/Version/Version6Interface.php
@@ -10,4 +10,11 @@ use Darsyn\IP\Contracts\Output6Interface;
 use Darsyn\IP\Contracts\StrategyDetectionInterface;
 use Darsyn\IP\IpInterface;
 
-interface Version6Interface extends IpInterface, Classification6Interface, Output6Interface, FactoryInterface, StrategyDetectionInterface {}
+interface Version6Interface extends IpInterface, Classification6Interface, Output6Interface, FactoryInterface, StrategyDetectionInterface
+{
+    /** @deprecated Use toExpandedAddress() instead. */
+    public function getExpandedAddress(): string;
+
+    /** @deprecated Use toCompactedAddress() instead. */
+    public function getCompactedAddress(/* ?ProtocolFormatterInterface $formatter = null */): string;
+}

--- a/tests/Strategy/Nat64Test.php
+++ b/tests/Strategy/Nat64Test.php
@@ -142,7 +142,7 @@ class Nat64Test extends TestCase
         $strategy = Nat64::networkSpecific(IPv6::fromProtocol($prefixAddress), $length);
         $this->assertSame(\pack('H*', $expectedPrefixHex), $strategy->getPrefix());
         $this->assertSame($length, $strategy->getPrefixLength());
-        $this->assertSame($prefixAddress, IPv6::fromBinary($strategy->getPrefix())->getCompactedAddress());
+        $this->assertSame($prefixAddress, IPv6::fromBinary($strategy->getPrefix())->toCompactedAddress());
     }
 
     /**
@@ -177,7 +177,7 @@ class Nat64Test extends TestCase
         $wellKnown = Nat64::wellKnown();
         $this->assertSame(\pack('H*', Nat64::WELL_KNOWN_PREFIX), $wellKnown->getPrefix());
         $this->assertSame(96, $wellKnown->getPrefixLength());
-        $this->assertSame('64:ff9b::', IPv6::fromBinary($wellKnown->getPrefix())->getCompactedAddress());
+        $this->assertSame('64:ff9b::', IPv6::fromBinary($wellKnown->getPrefix())->toCompactedAddress());
         $this->assertSame(
             Nat64::networkSpecific(IPv6::fromProtocol('64:ff9b::'), 96)->packIntoCanonical(\pack('H*', 'c0000221')),
             $wellKnown->packIntoCanonical(\pack('H*', 'c0000221'))
@@ -191,7 +191,7 @@ class Nat64Test extends TestCase
         $localUse = Nat64::localUse();
         $this->assertSame(\pack('H*', Nat64::LOCAL_USE_PREFIX), $localUse->getPrefix());
         $this->assertSame(48, $localUse->getPrefixLength());
-        $this->assertSame('64:ff9b:1::', IPv6::fromBinary($localUse->getPrefix())->getCompactedAddress());
+        $this->assertSame('64:ff9b:1::', IPv6::fromBinary($localUse->getPrefix())->toCompactedAddress());
     }
 
     /**

--- a/tests/Version/IPv4Test.php
+++ b/tests/Version/IPv4Test.php
@@ -138,7 +138,20 @@ class IPv4Test extends TestCase
     public function testDotAddressReturnsCorrectString(string $value, string $expectedHex, string $expectedDot): void
     {
         $ip = IP::fromProtocol($value);
-        $this->assertSame($expectedDot, $ip->getDotAddress());
+        $this->assertSame($expectedDot, $ip->toDotAddress());
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
+    #[PHPUnit\Test]
+    public function testGetDotAddressRemainsADeprecatedAliasForwardingTheFormatter(): void
+    {
+        $ip = IP::fromProtocol('127.0.0.1');
+        $this->assertSame($ip->toDotAddress(), $ip->getDotAddress());
+        $formatter = new StubFormatter();
+        $this->assertSame($ip->toDotAddress($formatter), $ip->getDotAddress($formatter));
     }
 
     /**
@@ -242,7 +255,7 @@ class IPv4Test extends TestCase
     public function testNetworkIp(string $expected, int $cidr): void
     {
         $ip = IP::fromProtocol('12.34.56.78');
-        $this->assertSame($expected, $ip->getNetworkIp($cidr)->getDotAddress());
+        $this->assertSame($expected, $ip->getNetworkIp($cidr)->toDotAddress());
     }
 
     /**
@@ -254,7 +267,7 @@ class IPv4Test extends TestCase
     public function testBroadcastIp(string $expected, int $cidr): void
     {
         $ip = IP::fromProtocol('12.34.56.78');
-        $this->assertSame($expected, $ip->getBroadcastIp($cidr)->getDotAddress());
+        $this->assertSame($expected, $ip->getBroadcastIp($cidr)->toDotAddress());
     }
 
     /**
@@ -267,7 +280,7 @@ class IPv4Test extends TestCase
     {
         $result = IP::fromProtocol($start)->offset($offset);
         $this->assertInstanceOf(IP::class, $result);
-        $this->assertSame($expected, $result->getDotAddress());
+        $this->assertSame($expected, $result->toDotAddress());
     }
 
     /** @test */
@@ -595,7 +608,7 @@ class IPv4Test extends TestCase
     public function testPerCallFormatterOverridesGlobal(): void
     {
         $ip = IP::fromProtocol('12.34.56.78');
-        $this->assertSame(StubFormatter::SENTINEL, $ip->getDotAddress(new StubFormatter()));
+        $this->assertSame(StubFormatter::SENTINEL, $ip->toDotAddress(new StubFormatter()));
     }
 
     /** @test */
@@ -603,8 +616,8 @@ class IPv4Test extends TestCase
     public function testPerCallFormatterDoesNotMutateGlobal(): void
     {
         $ip = IP::fromProtocol('12.34.56.78');
-        $this->assertSame(StubFormatter::SENTINEL, $ip->getDotAddress(new StubFormatter()));
-        $this->assertSame('12.34.56.78', $ip->getDotAddress());
+        $this->assertSame(StubFormatter::SENTINEL, $ip->toDotAddress(new StubFormatter()));
+        $this->assertSame('12.34.56.78', $ip->toDotAddress());
     }
 
     /** @test */
@@ -612,10 +625,13 @@ class IPv4Test extends TestCase
     public function testExplicitNullPerCallFormatterFallsBackToGlobal(): void
     {
         $ip = IP::fromProtocol('12.34.56.78');
-        $this->assertSame('12.34.56.78', $ip->getDotAddress(null));
+        $this->assertSame('12.34.56.78', $ip->toDotAddress(null));
     }
 
-    /** @test */
+    /**
+     * @test
+     * @deprecated
+     */
     #[PHPUnit\Test]
     public function testInvalidPerCallFormatterTriggersDeprecationAndFallsBack(): void
     {
@@ -628,7 +644,10 @@ class IPv4Test extends TestCase
         $this->assertSame('12.34.56.78', $result);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @deprecated
+     */
     #[PHPUnit\Test]
     public function testInvalidScalarPerCallFormatterMentionsTypeInDeprecation(): void
     {
@@ -703,7 +722,7 @@ class IPv4Test extends TestCase
         $ip = IP::fromBinary($value);
         $this->assertInstanceOf(Version4Interface::class, $ip);
         $this->assertSame($value, $ip->getBinary());
-        $this->assertSame($expectedDot, $ip->getDotAddress());
+        $this->assertSame($expectedDot, $ip->toDotAddress());
     }
 
     /** @test */

--- a/tests/Version/IPv6Test.php
+++ b/tests/Version/IPv6Test.php
@@ -143,14 +143,14 @@ class IPv6Test extends TestCase
         // IPv4 address can be embedded into IPv6 objects using the fromEmbedded() static instantiator.
         $embedded = IP::fromEmbedded('12.34.56.78', new Mapped());
         // But IPv6 objects should ignore the fact that it's embedded and only work with the full IPv6 address.
-        $this->assertSame('0000:1fff:ffff:ffff:ffff:ffff:ffff:ffff', $embedded->getBroadcastIp(19)->getExpandedAddress());
+        $this->assertSame('0000:1fff:ffff:ffff:ffff:ffff:ffff:ffff', $embedded->getBroadcastIp(19)->toExpandedAddress());
 
         // Multi objects understand both IPv4 and IPv6 addresses.
         $multi = Multi::fromProtocol('12.34.56.78', new Mapped());
         // So therefore, if a Multi object detects that it holds an embedded IPv4 address it will attempt to work with
         // the IPv4 address before falling back on the full IPv6 address.
-        $this->assertSame('0000:0000:0000:0000:0000:ffff:0c22:3fff', $multi->getBroadcastIp(19)->getExpandedAddress());
-        $this->assertSame('12.34.63.255', $multi->getBroadcastIp(19)->getDotAddress());
+        $this->assertSame('0000:0000:0000:0000:0000:ffff:0c22:3fff', $multi->getBroadcastIp(19)->toExpandedAddress());
+        $this->assertSame('12.34.63.255', $multi->getBroadcastIp(19)->toDotAddress());
     }
 
     /**
@@ -191,10 +191,10 @@ class IPv6Test extends TestCase
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv6DataProvider::class, 'getValidProtocolIpAddresses')]
-    public function testGetCompactedAddressReturnsCorrectString(string $value, string $hex, string $expanded, string $compacted): void
+    public function testCompactedAddressReturnsCorrectString(string $value, string $hex, string $expanded, string $compacted): void
     {
         $ip = IP::fromProtocol($value);
-        $this->assertSame($compacted, $ip->getCompactedAddress());
+        $this->assertSame($compacted, $ip->toCompactedAddress());
     }
 
     /**
@@ -203,10 +203,34 @@ class IPv6Test extends TestCase
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(IPv6DataProvider::class, 'getValidProtocolIpAddresses')]
-    public function testGetExpandedAddressReturnsCorrectString(string $value, string $hex, string $expanded, string $compacted): void
+    public function testExpandedAddressReturnsCorrectString(string $value, string $hex, string $expanded, string $compacted): void
     {
         $ip = IP::fromProtocol($value);
-        $this->assertSame($expanded, $ip->getExpandedAddress());
+        $this->assertSame($expanded, $ip->toExpandedAddress());
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
+    #[PHPUnit\Test]
+    public function testGetCompactedAddressRemainsADeprecatedAliasForwardingTheFormatter(): void
+    {
+        $ip = IP::fromProtocol('2001:db8::1');
+        $this->assertSame($ip->toCompactedAddress(), $ip->getCompactedAddress());
+        $formatter = new StubFormatter();
+        $this->assertSame($ip->toCompactedAddress($formatter), $ip->getCompactedAddress($formatter));
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
+    #[PHPUnit\Test]
+    public function testGetExpandedAddressRemainsADeprecatedAlias(): void
+    {
+        $ip = IP::fromProtocol('2001:db8::1');
+        $this->assertSame($ip->toExpandedAddress(), $ip->getExpandedAddress());
     }
 
     /**
@@ -310,7 +334,7 @@ class IPv6Test extends TestCase
     public function testNetworkIp(string $expected, int $cidr): void
     {
         $ip = IP::fromProtocol('2001:db8::a60:8a2e:370:7334');
-        $this->assertSame($expected, $ip->getNetworkIp($cidr)->getCompactedAddress());
+        $this->assertSame($expected, $ip->getNetworkIp($cidr)->toCompactedAddress());
     }
 
     /**
@@ -322,7 +346,7 @@ class IPv6Test extends TestCase
     public function testBroadcastIp(string $expected, int $cidr): void
     {
         $ip = IP::fromProtocol('2001:db8::a60:8a2e:370:7334');
-        $this->assertSame($expected, $ip->getBroadcastIp($cidr)->getCompactedAddress());
+        $this->assertSame($expected, $ip->getBroadcastIp($cidr)->toCompactedAddress());
     }
 
     /**
@@ -335,7 +359,7 @@ class IPv6Test extends TestCase
     {
         $result = IP::fromProtocol($start)->offset($offset);
         $this->assertInstanceOf(IP::class, $result);
-        $this->assertSame($expected, $result->getCompactedAddress());
+        $this->assertSame($expected, $result->toCompactedAddress());
     }
 
     /** @test */
@@ -672,7 +696,7 @@ class IPv6Test extends TestCase
     public function testPerCallFormatterOverridesGlobal(): void
     {
         $ip = IP::fromProtocol('2001:db8::a60:8a2e:370:7334');
-        $this->assertSame(StubFormatter::SENTINEL, $ip->getCompactedAddress(new StubFormatter()));
+        $this->assertSame(StubFormatter::SENTINEL, $ip->toCompactedAddress(new StubFormatter()));
     }
 
     /** @test */
@@ -680,9 +704,9 @@ class IPv6Test extends TestCase
     public function testPerCallNativeFormatterProducesNativeOutput(): void
     {
         $ip = IP::fromProtocol('::ffff:c22:384e');
-        $this->assertSame('::ffff:c22:384e', $ip->getCompactedAddress());
-        $this->assertSame('::ffff:12.34.56.78', $ip->getCompactedAddress(new NativeFormatter()));
-        $this->assertSame('::ffff:c22:384e', $ip->getCompactedAddress());
+        $this->assertSame('::ffff:c22:384e', $ip->toCompactedAddress());
+        $this->assertSame('::ffff:12.34.56.78', $ip->toCompactedAddress(new NativeFormatter()));
+        $this->assertSame('::ffff:c22:384e', $ip->toCompactedAddress());
     }
 
     /** @test */
@@ -690,10 +714,13 @@ class IPv6Test extends TestCase
     public function testExplicitNullPerCallFormatterFallsBackToGlobal(): void
     {
         $ip = IP::fromProtocol('::ffff:c22:384e');
-        $this->assertSame('::ffff:c22:384e', $ip->getCompactedAddress(null));
+        $this->assertSame('::ffff:c22:384e', $ip->toCompactedAddress(null));
     }
 
-    /** @test */
+    /**
+     * @test
+     * @deprecated
+     */
     #[PHPUnit\Test]
     public function testInvalidPerCallFormatterTriggersDeprecationAndFallsBack(): void
     {
@@ -766,8 +793,8 @@ class IPv6Test extends TestCase
         $ip = IP::fromBinary($value);
         $this->assertInstanceOf(Version6Interface::class, $ip);
         $this->assertSame($value, $ip->getBinary());
-        $this->assertSame($expanded, $ip->getExpandedAddress());
-        $this->assertSame($compacted, $ip->getCompactedAddress());
+        $this->assertSame($expanded, $ip->toExpandedAddress());
+        $this->assertSame($compacted, $ip->toCompactedAddress());
     }
 
     /** @test */
@@ -1080,7 +1107,7 @@ class IPv6Test extends TestCase
     {
         $embedded = IP::fromProtocol('::ffff:12.34.56.78')->getEmbeddedIp();
         $this->assertInstanceOf(IPv4::class, $embedded);
-        $this->assertSame('12.34.56.78', $embedded->getDotAddress());
+        $this->assertSame('12.34.56.78', $embedded->toDotAddress());
     }
 
     /** @test */
@@ -1097,7 +1124,7 @@ class IPv6Test extends TestCase
     public function testGetEmbeddedIpWithExplicitStrategy(): void
     {
         $ip = IP::fromProtocol('2002:c22:384e::');
-        $this->assertSame('12.34.56.78', $ip->getEmbeddedIp(new Derived())->getDotAddress());
+        $this->assertSame('12.34.56.78', $ip->getEmbeddedIp(new Derived())->toDotAddress());
     }
 
     /** @test */

--- a/tests/Version/MultiTest.php
+++ b/tests/Version/MultiTest.php
@@ -101,7 +101,7 @@ class MultiTest extends TestCase
     public function testEmbeddingStrategy(string $strategyClass, string $expandedAddress, string $v4address): void
     {
         $ip = IP::factory($v4address, new $strategyClass());
-        $this->assertSame($expandedAddress, $ip->getExpandedAddress());
+        $this->assertSame($expandedAddress, $ip->toExpandedAddress());
     }
 
     /**
@@ -115,7 +115,7 @@ class MultiTest extends TestCase
     {
         IP::setDefaultEmbeddingStrategy(new $strategyClass());
         $ip = IP::fromProtocol($v4address);
-        $this->assertSame($expandedAddress, $ip->getExpandedAddress());
+        $this->assertSame($expandedAddress, $ip->toExpandedAddress());
     }
 
     /**
@@ -182,10 +182,10 @@ class MultiTest extends TestCase
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(MultiDataProvider::class, 'getValidProtocolIpAddresses')]
-    public function testGetCompactedAddressReturnsCorrectString(string $value, string $hex, string $expanded, string $compacted, ?string $dot): void
+    public function testCompactedAddressReturnsCorrectString(string $value, string $hex, string $expanded, string $compacted, ?string $dot): void
     {
         $ip = IP::fromProtocol($value);
-        $this->assertSame($compacted, $ip->getCompactedAddress());
+        $this->assertSame($compacted, $ip->toCompactedAddress());
     }
 
     /**
@@ -194,10 +194,10 @@ class MultiTest extends TestCase
      */
     #[PHPUnit\Test]
     #[PHPUnit\DataProviderExternal(MultiDataProvider::class, 'getValidProtocolIpAddresses')]
-    public function testGetExpandedAddressReturnsCorrectString(string $value, string $hex, string $expanded, string $compacted, ?string $dot): void
+    public function testExpandedAddressReturnsCorrectString(string $value, string $hex, string $expanded, string $compacted, ?string $dot): void
     {
         $ip = IP::fromProtocol($value);
-        $this->assertSame($expanded, $ip->getExpandedAddress());
+        $this->assertSame($expanded, $ip->toExpandedAddress());
     }
 
     /**
@@ -209,7 +209,7 @@ class MultiTest extends TestCase
     public function testDotAddressReturnsCorrectString(string $value, string $hex, string $expanded, string $compacted, ?string $dot): void
     {
         $ip = IP::fromProtocol($value);
-        $this->assertSame($dot, $ip->getDotAddress());
+        $this->assertSame($dot, $ip->toDotAddress());
     }
 
     /**
@@ -223,7 +223,7 @@ class MultiTest extends TestCase
         $this->expectException(\Darsyn\IP\Exception\WrongVersionException::class);
         try {
             $ip = IP::fromProtocol($value);
-            $ip->getDotAddress();
+            $ip->toDotAddress();
         } catch (WrongVersionException $e) {
             $this->assertTrue(isset($ip));
             $this->assertSame((string) $ip, $e->getSuppliedIp());
@@ -231,6 +231,32 @@ class MultiTest extends TestCase
             $this->assertSame(6, $e->getActualVersion());
             throw $e;
         }
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
+    #[PHPUnit\Test]
+    public function testGetDotAddressRemainsADeprecatedAliasForwardingTheFormatter(): void
+    {
+        $ip = IP::fromProtocol('12.34.56.78');
+        $this->assertSame($ip->toDotAddress(), $ip->getDotAddress());
+        $formatter = new StubFormatter();
+        $this->assertSame($ip->toDotAddress($formatter), $ip->getDotAddress($formatter));
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
+    #[PHPUnit\Test]
+    public function testGetProtocolAppropriateAddressRemainsADeprecatedAliasForwardingTheFormatter(): void
+    {
+        $ip = IP::fromProtocol('2001:db8::1');
+        $this->assertSame($ip->toProtocolAppropriateAddress(), $ip->getProtocolAppropriateAddress());
+        $formatter = new StubFormatter();
+        $this->assertSame($ip->toProtocolAppropriateAddress($formatter), $ip->getProtocolAppropriateAddress($formatter));
     }
 
     /**
@@ -254,7 +280,7 @@ class MultiTest extends TestCase
     public function testNetworkIp(string $initial, string $expected, int $cidr): void
     {
         $ip = IP::fromProtocol($initial);
-        $this->assertSame($expected, $ip->getNetworkIp($cidr)->getProtocolAppropriateAddress());
+        $this->assertSame($expected, $ip->getNetworkIp($cidr)->toProtocolAppropriateAddress());
     }
 
     /**
@@ -266,7 +292,7 @@ class MultiTest extends TestCase
     public function testBroadcastIp(string $initial, string $expected, int $cidr): void
     {
         $ip = IP::fromProtocol($initial);
-        $this->assertSame($expected, $ip->getBroadcastIp($cidr)->getProtocolAppropriateAddress());
+        $this->assertSame($expected, $ip->getBroadcastIp($cidr)->toProtocolAppropriateAddress());
     }
 
     /**
@@ -279,7 +305,7 @@ class MultiTest extends TestCase
     {
         $result = IP::fromProtocol($start)->offset($offset);
         $this->assertInstanceOf(IP::class, $result);
-        $this->assertSame($expected, $result->getProtocolAppropriateAddress());
+        $this->assertSame($expected, $result->toProtocolAppropriateAddress());
     }
 
     /** @test */
@@ -406,7 +432,7 @@ class MultiTest extends TestCase
     public function testIsLoopbackCompatible(string $value, bool $isLoopback): void
     {
         $ip = IP::fromProtocol($value, new Strategy\Compatible());
-        if ('0000:0000:0000:0000:0000:0000:0000:0001' === $ip->getExpandedAddress()) {
+        if ('0000:0000:0000:0000:0000:0000:0000:0001' === $ip->toExpandedAddress()) {
             // Special case that I can't figure out a solution for.
             // The address 0.0.0.1 (when using the compatible embedding strategy)
             // is a loopback address if viewing as IPv6 (::1), but also not a
@@ -690,7 +716,7 @@ class MultiTest extends TestCase
     public function testPerCallFormatterOverridesGlobalForProtocolAppropriateAddress(): void
     {
         $ip = IP::fromProtocol('12.34.56.78');
-        $this->assertSame(StubFormatter::SENTINEL, $ip->getProtocolAppropriateAddress(new StubFormatter()));
+        $this->assertSame(StubFormatter::SENTINEL, $ip->toProtocolAppropriateAddress(new StubFormatter()));
     }
 
     /** @test */
@@ -698,8 +724,8 @@ class MultiTest extends TestCase
     public function testPerCallFormatterDoesNotMutateGlobalForProtocolAppropriateAddress(): void
     {
         $ip = IP::fromProtocol('12.34.56.78');
-        $this->assertSame(StubFormatter::SENTINEL, $ip->getProtocolAppropriateAddress(new StubFormatter()));
-        $this->assertSame('12.34.56.78', $ip->getProtocolAppropriateAddress());
+        $this->assertSame(StubFormatter::SENTINEL, $ip->toProtocolAppropriateAddress(new StubFormatter()));
+        $this->assertSame('12.34.56.78', $ip->toProtocolAppropriateAddress());
     }
 
     /** @test */
@@ -707,10 +733,13 @@ class MultiTest extends TestCase
     public function testExplicitNullPerCallFormatterFallsBackToGlobalForProtocolAppropriateAddress(): void
     {
         $ip = IP::fromProtocol('12.34.56.78');
-        $this->assertSame('12.34.56.78', $ip->getProtocolAppropriateAddress(null));
+        $this->assertSame('12.34.56.78', $ip->toProtocolAppropriateAddress(null));
     }
 
-    /** @test */
+    /**
+     * @test
+     * @deprecated
+     */
     #[PHPUnit\Test]
     public function testInvalidPerCallFormatterTriggersDeprecationForProtocolAppropriateAddress(): void
     {
@@ -728,7 +757,7 @@ class MultiTest extends TestCase
     public function testPerCallFormatterOverridesGlobalForDotAddress(): void
     {
         $ip = IP::fromProtocol('12.34.56.78');
-        $this->assertSame(StubFormatter::SENTINEL, $ip->getDotAddress(new StubFormatter()));
+        $this->assertSame(StubFormatter::SENTINEL, $ip->toDotAddress(new StubFormatter()));
     }
 
     /** @test */
@@ -736,8 +765,8 @@ class MultiTest extends TestCase
     public function testPerCallFormatterDoesNotMutateGlobalForDotAddress(): void
     {
         $ip = IP::fromProtocol('12.34.56.78');
-        $this->assertSame(StubFormatter::SENTINEL, $ip->getDotAddress(new StubFormatter()));
-        $this->assertSame('12.34.56.78', $ip->getDotAddress());
+        $this->assertSame(StubFormatter::SENTINEL, $ip->toDotAddress(new StubFormatter()));
+        $this->assertSame('12.34.56.78', $ip->toDotAddress());
     }
 
     /** @test */
@@ -745,10 +774,13 @@ class MultiTest extends TestCase
     public function testExplicitNullPerCallFormatterFallsBackToGlobalForDotAddress(): void
     {
         $ip = IP::fromProtocol('12.34.56.78');
-        $this->assertSame('12.34.56.78', $ip->getDotAddress(null));
+        $this->assertSame('12.34.56.78', $ip->toDotAddress(null));
     }
 
-    /** @test */
+    /**
+     * @test
+     * @deprecated
+     */
     #[PHPUnit\Test]
     public function testInvalidPerCallFormatterTriggersDeprecationForDotAddress(): void
     {
@@ -761,7 +793,10 @@ class MultiTest extends TestCase
         $this->assertSame('12.34.56.78', $result);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @deprecated
+     */
     #[PHPUnit\Test]
     public function testInvalidPerCallFormatterTriggersDeprecationForDotAddressOnNonEmbedded(): void
     {
@@ -841,10 +876,10 @@ class MultiTest extends TestCase
         $ip = IP::fromBinary($value);
         $this->assertInstanceOf(MultiVersionInterface::class, $ip);
         $this->assertSame($value, $ip->getBinary());
-        $this->assertSame($expanded, $ip->getExpandedAddress());
-        $this->assertSame($compacted, $ip->getCompactedAddress());
+        $this->assertSame($expanded, $ip->toExpandedAddress());
+        $this->assertSame($compacted, $ip->toCompactedAddress());
         if (null !== $dot) {
-            $this->assertSame($dot, $ip->getDotAddress());
+            $this->assertSame($dot, $ip->toDotAddress());
         }
     }
 
@@ -855,7 +890,7 @@ class MultiTest extends TestCase
         $ip = IP::fromBinary(Binary::fromHex('0c22384e'));
         $this->assertInstanceOf(MultiVersionInterface::class, $ip);
         $this->assertTrue($ip->isVersion4());
-        $this->assertSame('12.34.56.78', $ip->getDotAddress());
+        $this->assertSame('12.34.56.78', $ip->toDotAddress());
     }
 
     /** @test */
@@ -882,7 +917,7 @@ class MultiTest extends TestCase
     public function testFromProtocolUsesExplicitStrategy(string $strategyClass, string $expandedAddress, string $v4address): void
     {
         $ip = IP::fromProtocol($v4address, new $strategyClass());
-        $this->assertSame($expandedAddress, $ip->getExpandedAddress());
+        $this->assertSame($expandedAddress, $ip->toExpandedAddress());
     }
 
     /** @test */
@@ -890,7 +925,7 @@ class MultiTest extends TestCase
     public function testFromBinaryUsesExplicitStrategy(): void
     {
         $ip = IP::fromBinary(Binary::fromHex('0c22384e'), new Strategy\Derived());
-        $this->assertSame('2002:0c22:384e:0000:0000:0000:0000:0000', $ip->getExpandedAddress());
+        $this->assertSame('2002:0c22:384e:0000:0000:0000:0000:0000', $ip->toExpandedAddress());
     }
 
     /**
@@ -1011,7 +1046,7 @@ class MultiTest extends TestCase
     {
         $ip = IP::fromInteger(203569230);
         $this->assertSame('00000000000000000000ffff0c22384e', Binary::toHex($ip->getBinary()));
-        $this->assertSame('12.34.56.78', $ip->getProtocolAppropriateAddress());
+        $this->assertSame('12.34.56.78', $ip->toProtocolAppropriateAddress());
     }
 
     /** @test */
@@ -1019,7 +1054,7 @@ class MultiTest extends TestCase
     public function testFromIntegerUsesExplicitStrategy(): void
     {
         $ip = IP::fromInteger(203569230, new Strategy\Derived());
-        $this->assertSame('2002:0c22:384e:0000:0000:0000:0000:0000', $ip->getExpandedAddress());
+        $this->assertSame('2002:0c22:384e:0000:0000:0000:0000:0000', $ip->toExpandedAddress());
     }
 
     /**
@@ -1086,7 +1121,7 @@ class MultiTest extends TestCase
     public function testFromIntegerStringThreadsStrategy(): void
     {
         $ip = IP::fromIntegerString('281470885312590', new Strategy\Mapped());
-        $this->assertSame('12.34.56.78', $ip->getDotAddress());
+        $this->assertSame('12.34.56.78', $ip->toDotAddress());
     }
 
     /**
@@ -1152,7 +1187,7 @@ class MultiTest extends TestCase
         $ip = IP::fromProtocol('12.34.56.78', new Strategy\Derived());
         $embedded = $ip->getEmbeddedIp();
         $this->assertInstanceOf(IPv4::class, $embedded);
-        $this->assertSame('12.34.56.78', $embedded->getDotAddress());
+        $this->assertSame('12.34.56.78', $embedded->toDotAddress());
     }
 
     /** @test */
@@ -1203,7 +1238,7 @@ class MultiTest extends TestCase
     {
         $ip = IPv6::fromProtocol('2002:c22:384e::');
         IP::setDefaultEmbeddingStrategy(new Strategy\Derived());
-        $this->assertSame('12.34.56.78', $ip->getEmbeddedIp()->getDotAddress());
+        $this->assertSame('12.34.56.78', $ip->getEmbeddedIp()->toDotAddress());
         IP::setDefaultEmbeddingStrategy(new Strategy\Mapped());
     }
 }


### PR DESCRIPTION
- `to*` = convert the canonically-held binary representation to something
- `get*` = component and property accessors